### PR TITLE
Refactoring (and preliminary, orthogonal PDB alternate parsing changes)

### DIFF
--- a/src/edu/duke/cs/osprey/confspace/ConfSpace.java
+++ b/src/edu/duke/cs/osprey/confspace/ConfSpace.java
@@ -12,7 +12,7 @@ import cern.colt.matrix.linalg.Algebra;
 import cern.jet.math.Functions;
 import edu.duke.cs.osprey.bbfree.BBFreeBlock;
 import edu.duke.cs.osprey.control.EnvironmentVars;
-import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import edu.duke.cs.osprey.restypes.GenericResidueTemplateLibrary;
 import edu.duke.cs.osprey.dof.DegreeOfFreedom;
 import edu.duke.cs.osprey.dof.EllipseCoordDOF;
 import edu.duke.cs.osprey.dof.FreeDihedral;
@@ -169,7 +169,7 @@ public class ConfSpace implements Serializable {
             
             BBFreeBlock curBFB = getCurBFB(bfbList,res);
             
-            PositionConfSpace rcs = new PositionConfSpace(res, resDOFs, allowedAAs.get(pos), contSCFlex,
+            PositionConfSpace rcs = new PositionConfSpace(pos, res, resDOFs, allowedAAs.get(pos), contSCFlex,
                     resStrandDOFs, perts, dset.getPertIntervals(), dset.getPertStates(pos), curBFB, useEllipses);
             posFlex.add(rcs);
                         

--- a/src/edu/duke/cs/osprey/confspace/PositionConfSpace.java
+++ b/src/edu/duke/cs/osprey/confspace/PositionConfSpace.java
@@ -39,6 +39,7 @@ public class PositionConfSpace implements Serializable {
     public ArrayList<RC> RCs = new ArrayList<>();
     
     public Residue res;//The residue involved
+    public int designIndex;
     
     static double dihedFlexInterval = 9;// +/- 9 degree sidechain dihedral continuous flexibility...
     //later can allow this to vary across different dihedrals
@@ -59,6 +60,7 @@ public class PositionConfSpace implements Serializable {
         
         ResidueTemplateLibrary templateLib = EnvironmentVars.resTemplates;
         this.res = res;
+        designIndex = pos;
         
         
         if(pertStates==null){//no DEEPer flexibility...
@@ -73,7 +75,7 @@ public class PositionConfSpace implements Serializable {
         	// PGC 2015: Support backbone dependent rotamers.  
         	//	Compute phi and psi, necessary for backbone dependent rotamers.        
         	double phipsi [] = Protractor.getPhiPsi(this.res);
-            int numRot = templateLib.numRotForResType(pos, AAType, phipsi[0], phipsi[1]);
+            int numRot = templateLib.numRotForResType(designIndex, AAType, phipsi[0], phipsi[1]);
             
             //resDOFs is all sidechain DOFs, for now
             ArrayList<DegreeOfFreedom> dofListForRot = new ArrayList<>();
@@ -130,7 +132,7 @@ public class PositionConfSpace implements Serializable {
         //we'll start with the sidechain dihedral DOFs
 
         for(int dih=0; dih<numDihedrals; dih++){
-            dihValues[dih] = templateLib.getDihedralForRotamer(AAType,phipsi[0], phipsi[1], rot,dih);
+            dihValues[dih] = templateLib.getDihedralForRotamer(designIndex, AAType,phipsi[0], phipsi[1], rot,dih);
         }
         
         ArrayList<EllipseCoordDOF> ellCoords = makeEllCoords(useEllipses, dihValues, dofListForRot);

--- a/src/edu/duke/cs/osprey/confspace/PositionConfSpace.java
+++ b/src/edu/duke/cs/osprey/confspace/PositionConfSpace.java
@@ -21,6 +21,7 @@ import edu.duke.cs.osprey.dof.deeper.perts.Perturbation;
 import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
 import edu.duke.cs.osprey.structure.Residue;
 import edu.duke.cs.osprey.tools.*;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 
@@ -48,7 +49,7 @@ public class PositionConfSpace implements Serializable {
     
     ArrayList<EllipseCoordDOF> ellipsoidalDOFs = new ArrayList<>();
     
-    public PositionConfSpace(Residue res, ArrayList<DegreeOfFreedom> resDOFs, ArrayList<String> allowedAAs, 
+    public PositionConfSpace(int pos, Residue res, ArrayList<DegreeOfFreedom> resDOFs, ArrayList<String> allowedAAs, 
             boolean contSCFlex, ArrayList<DegreeOfFreedom> strandDOFs, 
             ArrayList<Perturbation> perts, ArrayList<ArrayList<double[]>> pertIntervals, 
             ArrayList<ArrayList<int[]>> pertStates, BBFreeBlock bfb, boolean useEllipses ) {
@@ -72,7 +73,7 @@ public class PositionConfSpace implements Serializable {
         	// PGC 2015: Support backbone dependent rotamers.  
         	//	Compute phi and psi, necessary for backbone dependent rotamers.        
         	double phipsi [] = Protractor.getPhiPsi(this.res);
-            int numRot = templateLib.numRotForResType(AAType, phipsi[0], phipsi[1]);
+            int numRot = templateLib.numRotForResType(pos, AAType, phipsi[0], phipsi[1]);
             
             //resDOFs is all sidechain DOFs, for now
             ArrayList<DegreeOfFreedom> dofListForRot = new ArrayList<>();

--- a/src/edu/duke/cs/osprey/control/ConfigFileParser.java
+++ b/src/edu/duke/cs/osprey/control/ConfigFileParser.java
@@ -9,7 +9,7 @@ import edu.duke.cs.osprey.dof.deeper.DEEPerSettings;
 import edu.duke.cs.osprey.dof.deeper.RamachandranChecker;
 import edu.duke.cs.osprey.ematrix.epic.EPICSettings;
 import edu.duke.cs.osprey.energy.EnergyFunctionGenerator;
-import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import edu.duke.cs.osprey.restypes.GenericResidueTemplateLibrary;
 import edu.duke.cs.osprey.energy.forcefield.ForcefieldParams;
 import edu.duke.cs.osprey.pruning.PruningControl;
 import edu.duke.cs.osprey.pruning.PruningMatrix;
@@ -261,7 +261,7 @@ public class ConfigFileParser {
         
         String[] resTemplateFiles = getResidueTemplateFiles(curForcefieldParams.forcefld);
         
-        ResidueTemplateLibrary resTemplates = new ResidueTemplateLibrary( resTemplateFiles, curForcefieldParams );
+        GenericResidueTemplateLibrary resTemplates = new GenericResidueTemplateLibrary( resTemplateFiles, curForcefieldParams );
         
         //load template coordinates (necessary for all residues we might want to mutate to)
         //these will be matched to templates

--- a/src/edu/duke/cs/osprey/control/ConfigFileParser.java
+++ b/src/edu/duke/cs/osprey/control/ConfigFileParser.java
@@ -234,7 +234,7 @@ public class ConfigFileParser {
     
     //loading of data files
     //residue templates, rotamer libraries, forcefield parameters, and Ramachandran data
-    void loadData(){
+    public void loadData(){
         
         EnvironmentVars.setDataDir(params.getValue("DataDir"));
         

--- a/src/edu/duke/cs/osprey/control/EnvironmentVars.java
+++ b/src/edu/duke/cs/osprey/control/EnvironmentVars.java
@@ -6,7 +6,7 @@ package edu.duke.cs.osprey.control;
 
 import edu.duke.cs.osprey.energy.EnergyFunctionGenerator;
 import edu.duke.cs.osprey.energy.forcefield.ForcefieldParams;
-import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import edu.duke.cs.osprey.restypes.GenericResidueTemplateLibrary;
 
 import java.math.BigInteger;
 
@@ -15,7 +15,7 @@ public class EnvironmentVars {
 	
 	//key parameter sets to use throughout the program for energy-function and flexibility reference
         public static EnergyFunctionGenerator curEFcnGenerator;
-        public static ResidueTemplateLibrary resTemplates;
+        public static GenericResidueTemplateLibrary resTemplates;
         
         //Regulation of structure read-in/template assignment
         public static boolean assignTemplatesToStruct = true;//Assign templates when we read in a template.

--- a/src/edu/duke/cs/osprey/control/GMECFinder.java
+++ b/src/edu/duke/cs/osprey/control/GMECFinder.java
@@ -79,8 +79,6 @@ public class GMECFinder {
         initializeParametersFromConfigFile(cfgP);
     }
 
-
-
     private void initializeParametersFromConfigFile (ConfigFileParser cfgP) {
         Ew = cfgP.params.getDouble("Ew",0);
         doIMinDEE = cfgP.params.getBool("imindee",false);

--- a/src/edu/duke/cs/osprey/control/GMECFinder.java
+++ b/src/edu/duke/cs/osprey/control/GMECFinder.java
@@ -108,7 +108,7 @@ public class GMECFinder {
     
     
    
-    double calcGMEC(){
+    public double calcGMEC(){
         //Calculate the GMEC
         
         double curInterval = I0;//For iMinDEE.  curInterval will need to be an upper bound

--- a/src/edu/duke/cs/osprey/control/GMECFinder.java
+++ b/src/edu/duke/cs/osprey/control/GMECFinder.java
@@ -33,6 +33,8 @@ public class GMECFinder {
     
     //KStarCalculator will be set up similarly to this class
     
+    //TODO: All of these variables should be PRIVATE in scope, unless they need to be public. -JJ
+    
     ConfigFileParser cfp;
     
     SearchProblem searchSpace;
@@ -72,6 +74,14 @@ public class GMECFinder {
         
         cfp = cfgP;
         
+        //TODO: Arguably, this is the initialization, which should be its own function. The constructor may eventually
+        // do other more interesting things and reading in member variables isn't that interesting. -JJ
+        initializeParametersFromConfigFile(cfgP);
+    }
+
+
+
+    private void initializeParametersFromConfigFile (ConfigFileParser cfgP) {
         Ew = cfgP.params.getDouble("Ew",0);
         doIMinDEE = cfgP.params.getBool("imindee",false);
         if(doIMinDEE){
@@ -118,7 +128,11 @@ public class GMECFinder {
             needToRepeat = false;
             
             //initialize a search problem with current Ival
-            checkEPICThresh2(curInterval);//Make sure EPIC thresh 2 matches current interval
+            // 11/11/2015 JJ: This logic belongs out here. A function that does nothing if a flag is false should 
+            // have its flag promoted outside of the function, unless it's used multiple times. In that case
+            // the function needs to be named accordingly.
+            if(useEPIC)
+                checkEPICThresh2(curInterval);//Make sure EPIC thresh 2 matches current interval
 
             precomputeMatrices(Ew+curInterval);//precompute the energy, pruning, and maybe EPIC or tup-exp matrices
             //must be done separately for each round of iMinDEE
@@ -235,6 +249,7 @@ public class GMECFinder {
             //we can prune conformations whose energies are within pruningInterval
             //of the lowest pairwise lower bound
             
+            // TODO: This feels like a hidden function. What does it actually do? -JJ
             if(EFullConfOnly){
                 fullConfOnlyTupExp();
                 return;
@@ -441,15 +456,12 @@ public class GMECFinder {
 
     
     private void checkEPICThresh2(double curInterval){
-                         
-        if(useEPIC){
-            if(curInterval+Ew>searchSpace.epicSettings.EPICThresh2){//need to raise EPICThresh2 
-                //to the point that we can guarantee no continuous component of the GMEC
-                //or desired ensemble will need to reach it
-                System.out.println("Raising EPICThresh2 to "+(curInterval+Ew)+" based on "
-                        + "iMinDEE interval and energy window");
-                searchSpace.epicSettings.EPICThresh2 = curInterval+Ew;
-            }
+        if(curInterval+Ew>searchSpace.epicSettings.EPICThresh2){//need to raise EPICThresh2 
+            //to the point that we can guarantee no continuous component of the GMEC
+            //or desired ensemble will need to reach it
+            System.out.println("Raising EPICThresh2 to "+(curInterval+Ew)+" based on "
+                    + "iMinDEE interval and energy window");
+            searchSpace.epicSettings.EPICThresh2 = curInterval+Ew;
         }
     }
     

--- a/src/edu/duke/cs/osprey/control/Main.java
+++ b/src/edu/duke/cs/osprey/control/Main.java
@@ -4,17 +4,10 @@
  */
 package edu.duke.cs.osprey.control;
 
-// TODO: Remove unnecessary imports. - JJ
 import java.util.HashMap;
 import java.util.Map;
-
-import cern.colt.matrix.DoubleMatrix1D;
-import cern.jet.math.Functions;
 import edu.duke.cs.osprey.energy.MultiTermEnergyFunction;
-import edu.duke.cs.osprey.minimization.CCDMinimizer;
-import edu.duke.cs.osprey.minimization.MolecEObjFunction;
 import edu.duke.cs.osprey.tests.UnitTestSuite;
-import edu.duke.cs.osprey.tools.ObjectIO;
 
 /**
  *
@@ -75,60 +68,57 @@ public class Main {
     }
     
     private static void initCommands(String[] args, ConfigFileParser cfp) {
-		// TODO Auto-generated method stub
-    	commands = new HashMap<String, Runnable>();
-    	
-    	commands.put("findGMEC",
-    			new Runnable()
-    			{
+        // TODO Auto-generated method stub
+        commands = new HashMap<String, Runnable>();
 
-					@Override
-					public void run() {
-						GMECFinder gf = new GMECFinder(cfp);
-						gf.calcGMEC();
-					}
-    		
-    			}
-    	);
-    	
-    	commands.put("calcKStar",
-    			new Runnable()
-    			{
+        commands.put("findGMEC",
+                new Runnable()
+        {
+            @Override
+            public void run() {
+                GMECFinder gf = new GMECFinder(cfp);
+                gf.calcGMEC();
+            }
 
-					@Override
-					public void run() {
-						System.err.println("Feature not implemented in this version.");
-					}
-    		
-    			}
-    	);
-    	
-    	commands.put("RunTests",
-    			new Runnable()
-    			{
+        }
+                );
 
-					@Override
-					public void run() {
-						UnitTestSuite.runAllTests();
-					}
-    		
-    			}
-    	);
-    	
-    	commands.put("doCOMETS",
-    			new Runnable()
-    			{
+        commands.put("calcKStar",
+                new Runnable()
+        {
 
-					@Override
-					public void run() {
-			            COMETSDoer cd = new COMETSDoer(args);
-			            cd.calcBestSequences();
-					}
-    		
-    			}
-    	);
-		
-	}
+            @Override
+            public void run() {
+                System.err.println("Feature not implemented in this version.");
+            }
+
+        }
+                );
+
+        commands.put("RunTests",
+                new Runnable()
+        {
+            @Override
+            public void run() {
+                UnitTestSuite.runAllTests();
+            }
+
+        }
+                );
+
+        commands.put("doCOMETS",
+                new Runnable()
+        {
+            @Override
+            public void run() {
+                COMETSDoer cd = new COMETSDoer(args);
+                cd.calcBestSequences();
+            }
+
+        }
+                );
+
+    }
 
 	// TODO: Move these into a test file, and just call it from the test.
     private static void debuggingCommands(String[] args){

--- a/src/edu/duke/cs/osprey/control/Main.java
+++ b/src/edu/duke/cs/osprey/control/Main.java
@@ -19,141 +19,141 @@ import edu.duke.cs.osprey.tests.UnitTestSuite;
 
 public class Main {
 
-    public static Map<String, Runnable> commands;
-    
-    public static void main(String[] args){
-        //args expected to be "-c KStar.cfg command config_file_1.cfg ..."
-        
-        debuggingCommands(args);
-        
-        String command = "";
-        try{
-        	command = args[2];
-        }
-        catch(Exception e){
-            // TODO: Replace with usage string, hardcoded outside of this function. - JJ
-        	System.out.println("Command expects arguments (e.g. -c KStar.cfg {findGMEC|fcalcKStar} System.cfg DEE.cfg");
-        	System.exit(1);
-        }
-        
-        
-        
-        long startTime = System.currentTimeMillis();
-        
-        ConfigFileParser cfp = new ConfigFileParser(args);//args 1, 3+ are configuration files
-        
-        //load data filescloneclone
-        cfp.loadData();        
-        
-        
-        
-        //DEBUG!!
-        // set number of threads for energy function evaluation
-        MultiTermEnergyFunction.setNumThreads( cfp.params.getInt("eEvalThreads", 4) );
-        if( MultiTermEnergyFunction.getNumThreads() > 1 ) {
-                System.setProperty( "java.util.concurrent.ForkJoinPool.common.parallelism", 
-                                String.valueOf(MultiTermEnergyFunction.getNumThreads()) );
-        }
-        
-        initCommands(args, cfp);
-        
-        if(commands.containsKey(command))
-        	commands.get(command).run();
-        else
-            throw new RuntimeException("ERROR: OSPREY command unrecognized: "+command);
-        
-        long endTime = System.currentTimeMillis();
-        System.out.println("Total OSPREY execution time: " + ((endTime-startTime)/60000) + " minutes.");
-        System.out.println("OSPREY finished");
-    }
-    
-    private static void initCommands(String[] args, ConfigFileParser cfp) {
-        // TODO Auto-generated method stub
-        commands = new HashMap<String, Runnable>();
+	public static Map<String, Runnable> commands;
 
-        commands.put("findGMEC",
-                new Runnable()
-        {
-            @Override
-            public void run() {
-                GMECFinder gf = new GMECFinder(cfp);
-                gf.calcGMEC();
-            }
+	public static void main(String[] args){
+		//args expected to be "-c KStar.cfg command config_file_1.cfg ..."
 
-        }
-                );
+		debuggingCommands(args);
 
-        commands.put("calcKStar",
-                new Runnable()
-        {
+		String command = "";
+		try{
+			command = args[2];
+		}
+		catch(Exception e){
+			// TODO: Replace with usage string, hardcoded outside of this function. - JJ
+			System.out.println("Command expects arguments (e.g. -c KStar.cfg {findGMEC|fcalcKStar} System.cfg DEE.cfg");
+			System.exit(1);
+		}
 
-            @Override
-            public void run() {
-                System.err.println("Feature not implemented in this version.");
-            }
 
-        }
-                );
 
-        commands.put("RunTests",
-                new Runnable()
-        {
-            @Override
-            public void run() {
-                UnitTestSuite.runAllTests();
-            }
+		long startTime = System.currentTimeMillis();
 
-        }
-                );
+		ConfigFileParser cfp = new ConfigFileParser(args);//args 1, 3+ are configuration files
 
-        commands.put("doCOMETS",
-                new Runnable()
-        {
-            @Override
-            public void run() {
-                COMETSDoer cd = new COMETSDoer(args);
-                cd.calcBestSequences();
-            }
+		//load data filescloneclone
+		cfp.loadData();        
 
-        }
-                );
 
-    }
+
+		//DEBUG!!
+		// set number of threads for energy function evaluation
+		MultiTermEnergyFunction.setNumThreads( cfp.params.getInt("eEvalThreads", 4) );
+		if( MultiTermEnergyFunction.getNumThreads() > 1 ) {
+			System.setProperty( "java.util.concurrent.ForkJoinPool.common.parallelism", 
+					String.valueOf(MultiTermEnergyFunction.getNumThreads()) );
+		}
+
+		initCommands(args, cfp);
+
+		if(commands.containsKey(command))
+			commands.get(command).run();
+		else
+			throw new RuntimeException("ERROR: OSPREY command unrecognized: "+command);
+
+		long endTime = System.currentTimeMillis();
+		System.out.println("Total OSPREY execution time: " + ((endTime-startTime)/60000) + " minutes.");
+		System.out.println("OSPREY finished");
+	}
+
+	private static void initCommands(String[] args, ConfigFileParser cfp) {
+		// TODO Auto-generated method stub
+		commands = new HashMap<String, Runnable>();
+
+		commands.put("findGMEC",
+				new Runnable()
+		{
+			@Override
+			public void run() {
+				GMECFinder gf = new GMECFinder(cfp);
+				gf.calcGMEC();
+			}
+
+		}
+				);
+
+		commands.put("calcKStar",
+				new Runnable()
+		{
+
+			@Override
+			public void run() {
+				System.err.println("Feature not implemented in this version.");
+			}
+
+		}
+				);
+
+		commands.put("RunTests",
+				new Runnable()
+		{
+			@Override
+			public void run() {
+				UnitTestSuite.runAllTests();
+			}
+
+		}
+				);
+
+		commands.put("doCOMETS",
+				new Runnable()
+		{
+			@Override
+			public void run() {
+				COMETSDoer cd = new COMETSDoer(args);
+				cd.calcBestSequences();
+			}
+
+		}
+				);
+
+	}
 
 	// TODO: Move these into a test file, and just call it from the test.
-    private static void debuggingCommands(String[] args){
-        
-        //MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697734046.dat", true);
-        /*MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697735769.dat", true);
-        
+	private static void debuggingCommands(String[] args){
+
+		//MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697734046.dat", true);
+		/*MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697735769.dat", true);
+
         CCDMinimizer minim = new CCDMinimizer(mof, false);
         DoubleMatrix1D bestVals = minim.minimize();
         double E = mof.getValue(bestVals);
-        
+
         DoubleMatrix1D boxBottom = bestVals.copy();
         DoubleMatrix1D boxTop = bestVals.copy();
         for(int q=0; q<bestVals.size(); q++){
             boxTop.set(q, Math.min(mof.getConstraints()[1].get(q), bestVals.get(q)+1));
             boxBottom.set(q, Math.max(mof.getConstraints()[0].get(q), bestVals.get(q)-1));
         }
-        
+
         for(int a=0; a<1000000; a++){
-            
+
             DoubleMatrix1D x2 = bestVals.like();
             for(int q=0; q<bestVals.size(); q++)
                 x2.set( q, boxBottom.get(q)+Math.random()*(boxTop.get(q)-boxBottom.get(q)) );
-            
+
             double E2 = mof.getValue(x2);
             if(E2 < E-0.1){
                 System.out.println("gg");
                 DoubleMatrix1D dx = x2.copy();
                 dx.assign( bestVals, Functions.minus );
-                
+
                 for(double t=1; true; t*=1.5){
                     dx.assign(Functions.mult(t));
                     x2.assign(dx);
                     x2.assign(bestVals, Functions.plus);
-                    
+
                     boolean oor = false;
                     for(int q=0; q<x2.size(); q++){
                         if( x2.get(q) > mof.getConstraints()[1].get(q) )
@@ -161,23 +161,23 @@ public class Main {
                         else if( x2.get(q) < mof.getConstraints()[0].get(q) )
                             oor = true;
                     }
-                    
+
                     if(oor)
                         break;
-                    
+
                     E2= mof.getValue(x2);
                     int aaa = 1;
                 }
             }
         }
-        
+
         System.exit(0);
-        */
-        //anything we want to try as an alternate main function, for debugging purposes
-        //likely will want to exit after doing this (specify here)
-        //for normal operation, leave no uncommented code in this function
-        
-    }
-    
-    
+		 */
+		//anything we want to try as an alternate main function, for debugging purposes
+		//likely will want to exit after doing this (specify here)
+		//for normal operation, leave no uncommented code in this function
+
+	}
+
+
 }

--- a/src/edu/duke/cs/osprey/control/Main.java
+++ b/src/edu/duke/cs/osprey/control/Main.java
@@ -5,6 +5,9 @@
 package edu.duke.cs.osprey.control;
 
 // TODO: Remove unnecessary imports. - JJ
+import java.util.HashMap;
+import java.util.Map;
+
 import cern.colt.matrix.DoubleMatrix1D;
 import cern.jet.math.Functions;
 import edu.duke.cs.osprey.energy.MultiTermEnergyFunction;
@@ -23,7 +26,7 @@ import edu.duke.cs.osprey.tools.ObjectIO;
 
 public class Main {
 
-    
+    public static Map<String, Runnable> commands;
     
     public static void main(String[] args){
         //args expected to be "-c KStar.cfg command config_file_1.cfg ..."
@@ -59,28 +62,10 @@ public class Main {
                                 String.valueOf(MultiTermEnergyFunction.getNumThreads()) );
         }
         
+        initCommands(args, cfp);
         
-        // TODO: Replace this with either the Factory Pattern, java reflection, or lambda functions. - JJ
-        if(command.equalsIgnoreCase("findGMEC")){
-            //I recommend that we change the command names a little to be more intuitive, e.g. 
-            //"findGMEC" instead of doDEE
-            GMECFinder gf = new GMECFinder(cfp);
-            gf.calcGMEC();//this can be the n globally minimum-energy conformations for n>1, or just the 1 
-            //These functions will handle their own output
-        }
-        else if(command.equalsIgnoreCase("calcKStar")){
-            throw new UnsupportedOperationException("ERROR: Still need to implement K*");
-            //KStarCalculator ksc = new KStarCalculator(params);
-            //ksc.calcKStarScores();
-        }
-        else if(command.equalsIgnoreCase("RunTests")){
-            UnitTestSuite.runAllTests();
-        }
-        else if(command.equalsIgnoreCase("doCOMETS")){
-            COMETSDoer cd = new COMETSDoer(args);
-            cd.calcBestSequences();
-        }
-        //etc.
+        if(commands.containsKey(command))
+        	commands.get(command).run();
         else
             throw new RuntimeException("ERROR: OSPREY command unrecognized: "+command);
         
@@ -89,7 +74,63 @@ public class Main {
         System.out.println("OSPREY finished");
     }
     
-    // TODO: Move these into a test file, and just call it from the test.
+    private static void initCommands(String[] args, ConfigFileParser cfp) {
+		// TODO Auto-generated method stub
+    	commands = new HashMap<String, Runnable>();
+    	
+    	commands.put("findGMEC",
+    			new Runnable()
+    			{
+
+					@Override
+					public void run() {
+						GMECFinder gf = new GMECFinder(cfp);
+						gf.calcGMEC();
+					}
+    		
+    			}
+    	);
+    	
+    	commands.put("calcKStar",
+    			new Runnable()
+    			{
+
+					@Override
+					public void run() {
+						System.err.println("Feature not implemented in this version.");
+					}
+    		
+    			}
+    	);
+    	
+    	commands.put("RunTests",
+    			new Runnable()
+    			{
+
+					@Override
+					public void run() {
+						UnitTestSuite.runAllTests();
+					}
+    		
+    			}
+    	);
+    	
+    	commands.put("doCOMETS",
+    			new Runnable()
+    			{
+
+					@Override
+					public void run() {
+			            COMETSDoer cd = new COMETSDoer(args);
+			            cd.calcBestSequences();
+					}
+    		
+    			}
+    	);
+		
+	}
+
+	// TODO: Move these into a test file, and just call it from the test.
     private static void debuggingCommands(String[] args){
         
         //MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697734046.dat", true);

--- a/src/edu/duke/cs/osprey/control/Main.java
+++ b/src/edu/duke/cs/osprey/control/Main.java
@@ -4,6 +4,7 @@
  */
 package edu.duke.cs.osprey.control;
 
+// TODO: Remove unnecessary imports. - JJ
 import cern.colt.matrix.DoubleMatrix1D;
 import cern.jet.math.Functions;
 import edu.duke.cs.osprey.energy.MultiTermEnergyFunction;
@@ -34,6 +35,7 @@ public class Main {
         	command = args[2];
         }
         catch(Exception e){
+            // TODO: Replace with usage string, hardcoded outside of this function. - JJ
         	System.out.println("Command expects arguments (e.g. -c KStar.cfg {findGMEC|fcalcKStar} System.cfg DEE.cfg");
         	System.exit(1);
         }
@@ -58,7 +60,7 @@ public class Main {
         }
         
         
-        
+        // TODO: Replace this with either the Factory Pattern, java reflection, or lambda functions. - JJ
         if(command.equalsIgnoreCase("findGMEC")){
             //I recommend that we change the command names a little to be more intuitive, e.g. 
             //"findGMEC" instead of doDEE
@@ -87,7 +89,7 @@ public class Main {
         System.out.println("OSPREY finished");
     }
     
-    
+    // TODO: Move these into a test file, and just call it from the test.
     private static void debuggingCommands(String[] args){
         
         //MolecEObjFunction mof = (MolecEObjFunction)ObjectIO.readObject("OBJFCN1442697734046.dat", true);

--- a/src/edu/duke/cs/osprey/control/ParamSet.java
+++ b/src/edu/duke/cs/osprey/control/ParamSet.java
@@ -78,6 +78,7 @@ public class ParamSet implements Serializable {
 			}
 			bufread.close();
 		}
+		//TODO: This is not where this error should be. The test is a single use case of a general class.
                 catch (FileNotFoundException e){
                     throw new RuntimeException("ERROR: Couldn't find configuration file "+fName+
                             "  Note: runTests must be run in test/1CC8 directory.");
@@ -124,6 +125,17 @@ public class ParamSet implements Serializable {
         public String getValue(String paramName){
             return getValue(paramName,null);
         }
+        
+        /* TODO: We absolutely have to stop passing in the default value as part of the function.
+         * Either we have a real default value which should be in a file of constants, or this is a
+         * function-specific initial value, and is not a constant. In that case our code should read:
+         * 
+         * int intParameter = 0; <- Initial value. 
+         * if(params.containsParameter("ExampleInteger")
+         *      intParameter = params.getInt("ExampleInteger");
+         *      
+         * This is three lines and a hassle to write but getInt("XYZ",4) is inscrutable.
+         */
         
         //The following methods return a parameter expected to be a certain non-string type
         //It's an error if they're not that type

--- a/src/edu/duke/cs/osprey/dof/ResidueTypeDOF.java
+++ b/src/edu/duke/cs/osprey/dof/ResidueTypeDOF.java
@@ -8,7 +8,7 @@ import edu.duke.cs.osprey.control.EnvironmentVars;
 import edu.duke.cs.osprey.dof.deeper.SidechainIdealizer;
 import edu.duke.cs.osprey.restypes.HardCodedResidueInfo;
 import edu.duke.cs.osprey.restypes.ResidueTemplate;
-import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import edu.duke.cs.osprey.restypes.GenericResidueTemplateLibrary;
 import edu.duke.cs.osprey.structure.Atom;
 import edu.duke.cs.osprey.structure.Residue;
 import edu.duke.cs.osprey.tools.RigidBodyMotion;
@@ -34,7 +34,7 @@ public class ResidueTypeDOF extends DegreeOfFreedom {
     public void mutateTo(String resType) {
         //paramVal is the index in the ResidueTemplateLibrary of the new parameter type
         //so it must be an integer...
-        ResidueTemplateLibrary templateLib = EnvironmentVars.resTemplates;
+        GenericResidueTemplateLibrary templateLib = EnvironmentVars.resTemplates;
         
         ResidueTemplate oldTemplate = res.template;
         ResidueTemplate newTemplate = templateLib.getTemplateForMutation(resType,res,true);

--- a/src/edu/duke/cs/osprey/restypes/GenericResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/GenericResidueTemplateLibrary.java
@@ -1,0 +1,359 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package edu.duke.cs.osprey.restypes;
+
+import edu.duke.cs.osprey.control.EnvironmentVars;
+import edu.duke.cs.osprey.energy.forcefield.ForcefieldParams;
+import edu.duke.cs.osprey.structure.Atom;
+import edu.duke.cs.osprey.structure.Residue;
+import edu.duke.cs.osprey.tools.StringParsing;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+
+/**
+ *
+ * @author mhall44
+ */
+public class GenericResidueTemplateLibrary extends ResidueTemplateLibrary {
+    //This library of residue templates defines what types of residues we can model
+    //and what flexibility and energy parameters come with each type
+    //NAMING: We assume each distinct residue (AA or otherwise) has its own name
+    //however, many residues will have multiple slightly different forms (N-terminal, etc.) 
+    //and these will share a name and a rotamer library entry
+    
+    
+
+    
+    public int totalNumRotamers = 0;//total number of rotamers read in from rotamer library file(s)
+    //starts at 0
+    
+    //the templates contain forcefield information like atom types, so they need to go with 
+    //a set of forcefield parameters
+    public ForcefieldParams ffParams;
+    
+    public GenericResidueTemplateLibrary(String[] templateFiles, ForcefieldParams fp){
+        //create a library based on template files
+        //we can then load coordinates and rotamer libraries for these templates separately, if we have these
+
+        ffParams = fp;
+        
+        for(String fileName : templateFiles){
+            loadTemplates(fileName);
+        }
+    }
+        
+        
+    public void loadTemplates(String templateFile){//load templates from the indicated files,
+        //and add them to our list of templates
+        try {
+
+            FileInputStream is = new FileInputStream( EnvironmentVars.getDataDir().concat(templateFile) );
+            BufferedReader bufread = new BufferedReader(new InputStreamReader(is));
+
+            // Skip over first 2 lines of header info
+            bufread.readLine();
+            bufread.readLine();
+
+            while(true) {//read all the templates
+                //at the beginning of this loop, curLine is the long amino acid name,
+                //which we discard.  readTemplate will thus start reading the next line
+                ResidueTemplate newTemplate = readTemplate(bufread);
+                if(newTemplate==null)//null newTemplate means lines needed to be skipped or something
+                    break;
+                else {
+                    templates.add(newTemplate);
+                }
+            }
+            bufread.close();
+        }
+        
+        catch (FileNotFoundException e) {
+                System.out.println("ERROR: Template File Not Found: "+e);
+                e.printStackTrace();
+                System.exit(0);
+        }
+        catch (IOException e) {
+                System.out.println("ERROR reading template file: "+e);
+                e.printStackTrace();
+                System.exit(0);
+        }
+    }
+    
+
+    
+    private ResidueTemplate readTemplate (BufferedReader bufread) throws IOException {
+        //read a template from the BufferedReader provided (it reads a template file)
+        //null means all templates already read from file
+        
+        String curLine = bufread.readLine();
+        if(curLine==null)//file ended!
+            return null;
+        else if (curLine.length() >= 4){
+                if (curLine.substring(0,4).equalsIgnoreCase("stop")) {
+                        curLine = bufread.readLine();
+                        return null;//finished reading file!
+                }
+        }
+        // Skip blank line
+        curLine = bufread.readLine();
+        // The next line contains the 3 letter amino acid name
+        curLine = bufread.readLine();
+        String templateName = StringParsing.getToken(curLine,1);
+        
+        // Skip next 2 lines
+        curLine = bufread.readLine();
+        curLine = bufread.readLine();
+        // Now we're into the section with atoms
+        curLine = bufread.readLine();
+        // Skip the dummy atoms
+        int dumPresent = 0;
+        while (StringParsing.getToken(curLine,2).equalsIgnoreCase("DUMM")) {
+                dumPresent++;
+                curLine = bufread.readLine();
+        }
+        dumPresent++; // to adjust for 0-based
+        
+        ArrayList<Atom> atomList = new ArrayList<>();
+        
+        while (!StringParsing.getToken(curLine,2).equals("")) {//read info on atoms
+                String atomName = StringParsing.getToken(curLine,2);
+                Atom at = new Atom (atomName);
+                
+                at.forceFieldType = StringParsing.getToken(curLine,3);
+                at.type = ffParams.atomTypeToInt(at.forceFieldType);
+                at.charge = (double) (new Double(StringParsing.getToken(curLine,11)).doubleValue());
+
+                //the template only records bonds within the residue
+                
+                //KER: The first atom is bonded to a dummy atom so we can't include that
+                //KER: in the bond list, so check atom is >= 0
+                int atomBondedTo = ((new Integer(StringParsing.getToken(curLine,5))).intValue())-dumPresent;
+                if(atomBondedTo >=0){
+                        at.addBond(atomList.get(atomBondedTo));
+                }
+                
+                atomList.add(at);
+                curLine = bufread.readLine();  // read next line
+        }
+
+        
+        Residue templateRes = new Residue(atomList,null,templateName,null);//no molecule or coordinates yets
+
+
+        do {//we expect one or more blank lines before the LOOP and IMPROPER records
+            curLine = bufread.readLine();
+        }
+        while(curLine.trim().isEmpty());
+        
+        //KER: Read LOOP data if any
+        if (curLine.length() >= 4){
+                if(StringParsing.getToken(curLine, 1).equalsIgnoreCase("LOOP")){
+                        curLine = bufread.readLine();
+                        while(!StringParsing.getToken(curLine,2).equals("")){
+                                //find atom1
+                                for(Atom a : atomList){
+                                        if(a.name.equalsIgnoreCase(StringParsing.getToken(curLine,1))){
+                                                //find atom2
+                                                for(Atom b : atomList){
+                                                        if(b.name.equalsIgnoreCase(StringParsing.getToken(curLine,2))){
+                                                                a.addBond(b);
+                                                        }
+                                                }
+                                        }
+                                }
+                                curLine = bufread.readLine();
+                        }
+                }
+        }
+        
+        //at this point templateRes has all its intra-res bonds all marked
+        templateRes.intraResBondsMarked = true;
+
+        // Eventually we might want to be able to handle the improper
+        //  torsions listed here
+
+        
+        // Read until the end of the residue
+        boolean atDone = false;
+        if (curLine.length() >= 4)
+                atDone = curLine.substring(0,4).equalsIgnoreCase("done");
+        else
+                atDone = false;
+        while (!atDone) {
+                curLine = bufread.readLine();
+                if (curLine.length() >= 4)
+                        atDone = curLine.substring(0,4).equalsIgnoreCase("done");
+        }
+        
+        
+        ResidueTemplate newTemplate = new ResidueTemplate(templateRes,templateName);
+        return newTemplate;
+    }
+    
+    
+    
+    public void loadTemplateCoords(String fileName){
+        //load coordinates for templates, given in the following file
+        //they should match templates that are already loaded (same residue and atom names)
+        //we will need coordinates for any residue type that we mutate to
+        
+        try {
+                
+            FileInputStream is = new FileInputStream( EnvironmentVars.getDataDir().concat(fileName) );
+            BufferedReader bufread = new BufferedReader(new InputStreamReader(is));
+            String curLine = null, tmpName = null;
+            int tmpCtr = 0;
+
+            curLine = bufread.readLine();
+            while ( curLine.startsWith("#") ){
+                    curLine = bufread.readLine();
+            }
+            boolean foundRes = false;
+            boolean foundAtom = false;
+            while (curLine != null ){
+                    String resName = StringParsing.getToken(curLine,1);
+                    int numAtoms = new Integer(StringParsing.getToken(curLine,2)); 
+                    foundRes = false;
+                    for(ResidueTemplate template : templates){//find the template to assign these coordinates to
+            
+                        if(template.name.equalsIgnoreCase(resName)){//found it
+                            
+                                Residue r = template.templateRes;
+                                if(r.atoms.size()!=numAtoms)
+                                    throw new RuntimeException("ERROR: Coords file has wrong number of atoms for "+r.fullName);
+
+                                r.coords = new double[3*numAtoms];//allocate coordinates
+
+                                foundRes = true;
+                                for(int i=0;i<numAtoms;i++){
+                                        curLine = bufread.readLine();
+                                        //Find the current atom in the residue
+                                        foundAtom = false;
+                                        for(int atNum=0; atNum<numAtoms; atNum++){
+                                                Atom at = r.atoms.get(atNum);
+                                                if(at.name.equalsIgnoreCase(StringParsing.getToken(curLine,1))){
+                                                        foundAtom = true;
+                                                        //read coordinates for this atom
+                                                        double x = new Double(StringParsing.getToken(curLine,2));
+                                                        double y = new Double(StringParsing.getToken(curLine,3)); 
+                                                        double z = new Double(StringParsing.getToken(curLine,4));
+                                                        r.coords[3*atNum] = x;
+                                                        r.coords[3*atNum+1] = y;
+                                                        r.coords[3*atNum+2] = z;
+                                                        break;
+                                                }
+                                        }
+                                        if(!foundAtom){
+                                                System.out.println("Residue coord and forcefield templates did not match up.");
+                                                System.exit(0);
+                                                //Possible issue: first occurrence of this name in the template residues is the wrong form for these coordinates?
+                                        }		
+                                }
+                                break;
+                        }
+                    }
+                    //If we didn't find a match we need to get rid of those 
+                    //lines from the file
+                    if(!foundRes){
+                            for(int i=0; i<numAtoms;i++){
+                                    curLine=bufread.readLine();
+                            }
+                    }
+                    //Read to catch the ENDRES line and then
+                    //get the start of the next AA
+                    curLine = bufread.readLine();
+                    curLine = bufread.readLine();
+            }
+            bufread.close();
+        }
+        catch (FileNotFoundException e) {
+                System.out.println("ERROR: Template File Not Found: "+e);
+                e.printStackTrace();
+                System.exit(0);
+        }
+        catch (IOException e) {
+                System.out.println("ERROR reading template file: "+e);
+                e.printStackTrace();
+                System.exit(0);
+        }
+        
+    }
+    
+    /** 
+     * PGC 2015: Supporting two rotamer libraries right now, Lovell and Dunbrack backbone dependent rotamers.
+     * load rotamer information into templates.
+     * @param filename for Lovell-style or Dunbrack Rotamer Library.
+     * @param backbone_dependent_rotamers Use Dunbrack Rotamer Library? 
+     */
+    public void loadRotamerLibrary(String fileName, boolean dunbrack_backbone_dependent_rotamers){
+
+        if(dunbrack_backbone_dependent_rotamers){
+        	RotamerLibraryReader.readDunbrackRotamerLibraryForResiduePosition(fileName, this);
+        }
+        else{
+        	RotamerLibraryReader.readRotLibrary(fileName, this);
+        }
+        //read volume here too?
+        
+    }
+    
+    
+    
+    public ResidueTemplate getTemplateForMutation(String resTypeName, Residue res, boolean errorIfNone){
+        //We want to mutate res to type resTypeName.  Get the appropriate template.
+        //Currently only one template capable of being mutated to (i.e., having coordinates)
+        //is available for each residue type.  If this changes update here!
+        for(ResidueTemplate template : templates){
+            if(template.name.equalsIgnoreCase(resTypeName)){
+                if(template.templateRes.coords!=null){
+                    //we have coordinates for templateRes, so can mutate to it
+                    return template;
+                }
+            }
+        }
+        
+        if(errorIfNone){//actually trying to mutate...throw an error if can't get a mutation
+            throw new RuntimeException("ERROR: Couldn't find a template for mutating "+res.fullName
+                    +" to "+resTypeName);
+        }
+        else//just checking if template available for mutation...return null to indicate not possible
+            return null;
+    }
+    
+    
+    public void makeDAminoAcidTemplates(){
+        //Make a D-amino acid template for every standard L-amino acid template in the library
+        //This lets us do D-amino acids without having to have separate templates
+        //A D-amino acid is just an inverted L-amino acid (including Ile and Thr,
+        //which have a second chiral center)
+        ArrayList<ResidueTemplate> DTemplates = new ArrayList<>();
+        
+        for(ResidueTemplate template : templates){
+            
+            if( DAminoAcidHandler.isStandardLAminoAcid(template.name) ){
+                //template recognized as standard L-amino acid
+                
+                DTemplates.add( DAminoAcidHandler.makeDTemplate(template) );
+            }
+        }
+        
+        templates.addAll(DTemplates);
+    }
+
+
+	@Override
+	public int numRotForResType(int pos, String resType, double phi, double psi) {
+	    return firstTemplate(resType).getNumRotamers(phi, psi);
+	}
+
+    
+}
+

--- a/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
@@ -13,26 +13,34 @@ import edu.duke.cs.osprey.structure.Residue;
  * @author JJ
  *
  */
-public class PositionSpecificRotamerLibrary {
+public class PositionSpecificRotamerLibrary extends ResidueTemplateLibrary {
     
     public static PositionSpecificRotamerLibrary generateLibraryFromPDB(String pdbFileName)
     {
         Molecule m = PDBFileReader.readPDBFile(pdbFileName);
         PDBRotamerReader.addAlternates(m, pdbFileName);
         
+        PositionSpecificRotamerLibrary library = new PositionSpecificRotamerLibrary();
+        
         for(Residue r: m.residues)
         {
             outputResidueTemplateInfo(r);
+            library.addResidueTemplate(r.template);
         }
-        return new PositionSpecificRotamerLibrary();
+        return library;
     }
     
-    private void PositionSpecificRotamerLibrary()
-    {
-        
-    }
+    // This constructor left intentionally empty. Never create one in a non-static fashion.
+    private void PositionSpecificRotamerLibrary(){}
     
     private static void outputResidueTemplateInfo(Residue r)
     {
     }
+    
+
+	@Override
+	public int numRotForResType(int pos, String resType, double phi, double psi) {
+		// TODO Auto-generated method stub
+		return 0;
+	}
 }

--- a/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
@@ -1,0 +1,38 @@
+package edu.duke.cs.osprey.restypes;
+
+import edu.duke.cs.osprey.structure.Molecule;
+import edu.duke.cs.osprey.structure.PDBFileReader;
+import edu.duke.cs.osprey.structure.PDBRotamerReader;
+import edu.duke.cs.osprey.structure.Residue;
+
+/***
+ * Rotamer library which specifies specific rotamers at 
+ * each design position. Used for generating alternate
+ * conformations when input structure is sufficiently high 
+ * resolution.
+ * @author JJ
+ *
+ */
+public class PositionSpecificRotamerLibrary {
+    
+    public static PositionSpecificRotamerLibrary generateLibraryFromPDB(String pdbFileName)
+    {
+        Molecule m = PDBFileReader.readPDBFile(pdbFileName);
+        PDBRotamerReader.addAlternates(m, pdbFileName);
+        
+        for(Residue r: m.residues)
+        {
+            outputResidueTemplateInfo(r);
+        }
+        return new PositionSpecificRotamerLibrary();
+    }
+    
+    private void PositionSpecificRotamerLibrary()
+    {
+        
+    }
+    
+    private static void outputResidueTemplateInfo(Residue r)
+    {
+    }
+}

--- a/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
@@ -19,54 +19,54 @@ import edu.duke.cs.osprey.structure.Residue;
  */
 public class PositionSpecificRotamerLibrary extends ResidueTemplateLibrary {
 
-    private Map<Integer, Map<String, List<ResidueTemplate>>> positionSpecificRotamers = new HashMap<>();
-    public static PositionSpecificRotamerLibrary generateLibraryFromPDB(String pdbFileName)
-    {
+	private Map<Integer, Map<String, List<ResidueTemplate>>> positionSpecificRotamers = new HashMap<>();
+	public static PositionSpecificRotamerLibrary generateLibraryFromPDB(String pdbFileName)
+	{
 
-        PositionSpecificRotamerLibrary library = new PositionSpecificRotamerLibrary();
-        Molecule m = PDBFileReader.readPDBFile(pdbFileName);
-        PDBRotamerReader.createTemplates(m, library, pdbFileName);
-
-
-        for(Residue r: m.residues)
-        {
-            outputResidueTemplateInfo(r);
-        }
-        return library;
-    }
-
-    // This constructor left intentionally empty. Never create one in a non-static fashion.
-    private void PositionSpecificRotamerLibrary(){}
-
-    private static void outputResidueTemplateInfo(Residue r)
-    {
-    }
+		PositionSpecificRotamerLibrary library = new PositionSpecificRotamerLibrary();
+		Molecule m = PDBFileReader.readPDBFile(pdbFileName);
+		PDBRotamerReader.createTemplates(m, library, pdbFileName);
 
 
-    @Override
-    public int numRotForResType(int pos, String resType, double phi, double psi) {
-        Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
-        return templatesAtDesignIndex.get(resType).size();
-    }
-    
-    @Override
-    public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
-            int rotNum, int dihedralNum) {
-                Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
-                return templatesAtDesignIndex.get(resType).get(pos).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
-            }
+		for(Residue r: m.residues)
+		{
+			outputResidueTemplateInfo(r);
+		}
+		return library;
+	}
 
-    private Map<String, List<ResidueTemplate>> getTemplatesForDesignIndex (int pos) {
-        if(!positionSpecificRotamers.containsKey(pos))
-            positionSpecificRotamers.put(pos, new HashMap<>());
-        return positionSpecificRotamers.get(pos);
-    }
+	// This constructor left intentionally empty. Never create one in a non-static fashion.
+	private void PositionSpecificRotamerLibrary(){}
 
-    public void addResidueTemplate (int residueIndex, String resType, ResidueTemplate allowedConformations) {
-        // TODO Auto-generated method stub
-        Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(residueIndex);
-        if(!templatesAtDesignIndex.containsKey(resType))
-            templatesAtDesignIndex.put(resType, new ArrayList<ResidueTemplate>());
-        templatesAtDesignIndex.get(resType).add(allowedConformations);
-    }
+	private static void outputResidueTemplateInfo(Residue r)
+	{
+	}
+
+
+	@Override
+	public int numRotForResType(int pos, String resType, double phi, double psi) {
+		Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
+		return templatesAtDesignIndex.get(resType).size();
+	}
+
+	@Override
+	public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
+			int rotNum, int dihedralNum) {
+		Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
+		return templatesAtDesignIndex.get(resType).get(pos).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
+	}
+
+	private Map<String, List<ResidueTemplate>> getTemplatesForDesignIndex (int pos) {
+		if(!positionSpecificRotamers.containsKey(pos))
+			positionSpecificRotamers.put(pos, new HashMap<>());
+		return positionSpecificRotamers.get(pos);
+	}
+
+	public void addResidueTemplate (int residueIndex, String resType, ResidueTemplate allowedConformations) {
+		// TODO Auto-generated method stub
+		Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(residueIndex);
+		if(!templatesAtDesignIndex.containsKey(resType))
+			templatesAtDesignIndex.put(resType, new ArrayList<ResidueTemplate>());
+		templatesAtDesignIndex.get(resType).add(allowedConformations);
+	}
 }

--- a/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/PositionSpecificRotamerLibrary.java
@@ -1,5 +1,9 @@
 package edu.duke.cs.osprey.restypes;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import edu.duke.cs.osprey.structure.Molecule;
 import edu.duke.cs.osprey.structure.PDBFileReader;
 import edu.duke.cs.osprey.structure.PDBRotamerReader;
@@ -14,33 +18,55 @@ import edu.duke.cs.osprey.structure.Residue;
  *
  */
 public class PositionSpecificRotamerLibrary extends ResidueTemplateLibrary {
-    
+
+    private Map<Integer, Map<String, List<ResidueTemplate>>> positionSpecificRotamers = new HashMap<>();
     public static PositionSpecificRotamerLibrary generateLibraryFromPDB(String pdbFileName)
     {
-        Molecule m = PDBFileReader.readPDBFile(pdbFileName);
-        PDBRotamerReader.addAlternates(m, pdbFileName);
-        
+
         PositionSpecificRotamerLibrary library = new PositionSpecificRotamerLibrary();
-        
+        Molecule m = PDBFileReader.readPDBFile(pdbFileName);
+        PDBRotamerReader.createTemplates(m, library, pdbFileName);
+
+
         for(Residue r: m.residues)
         {
             outputResidueTemplateInfo(r);
-            library.addResidueTemplate(r.template);
         }
         return library;
     }
-    
+
     // This constructor left intentionally empty. Never create one in a non-static fashion.
     private void PositionSpecificRotamerLibrary(){}
-    
+
     private static void outputResidueTemplateInfo(Residue r)
     {
     }
-    
 
-	@Override
-	public int numRotForResType(int pos, String resType, double phi, double psi) {
-		// TODO Auto-generated method stub
-		return 0;
-	}
+
+    @Override
+    public int numRotForResType(int pos, String resType, double phi, double psi) {
+        Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
+        return templatesAtDesignIndex.get(resType).size();
+    }
+    
+    @Override
+    public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
+            int rotNum, int dihedralNum) {
+                Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(pos);
+                return templatesAtDesignIndex.get(resType).get(pos).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
+            }
+
+    private Map<String, List<ResidueTemplate>> getTemplatesForDesignIndex (int pos) {
+        if(!positionSpecificRotamers.containsKey(pos))
+            positionSpecificRotamers.put(pos, new HashMap<>());
+        return positionSpecificRotamers.get(pos);
+    }
+
+    public void addResidueTemplate (int residueIndex, String resType, ResidueTemplate allowedConformations) {
+        // TODO Auto-generated method stub
+        Map<String, List<ResidueTemplate>> templatesAtDesignIndex = getTemplatesForDesignIndex(residueIndex);
+        if(!templatesAtDesignIndex.containsKey(resType))
+            templatesAtDesignIndex.put(resType, new ArrayList<ResidueTemplate>());
+        templatesAtDesignIndex.get(resType).add(allowedConformations);
+    }
 }

--- a/src/edu/duke/cs/osprey/restypes/ResTemplateMatching.java
+++ b/src/edu/duke/cs/osprey/restypes/ResTemplateMatching.java
@@ -49,6 +49,7 @@ public class ResTemplateMatching {
         numAtoms = templateAtoms.size();
         
         if( res.atoms.size() != numAtoms ){//matching impossible: not even number of atoms matches
+            //System.out.println("Missing atoms... Matching will be best, not exact.");
             return;
         }
         
@@ -93,7 +94,7 @@ public class ResTemplateMatching {
         //DFS over permutations of atoms, starting at current level (indicates which atom
         //in the template we want to match next)
         
-        if(level==numAtoms){//all atoms defined...let's score this matching
+        if(level==numAtoms || level >= res.atoms.size()){//all atoms defined...let's score this matching
             //when we get a full permutation, we score it based on least-square length difference for the template bonds.
             double curMatchingScore = scoreCurPartialMatching();
             if(curMatchingScore<score){//best so far
@@ -103,7 +104,7 @@ public class ResTemplateMatching {
         }
         else {//need to search more levels
 
-            for(int resAtNum=0; resAtNum<numAtoms; resAtNum++){
+            for(int resAtNum=0; resAtNum<res.atoms.size(); resAtNum++){
                 if(!atomAlreadyInPartialMatching(resAtNum,level)){
                     
                     //make sure element types match
@@ -176,7 +177,10 @@ public class ResTemplateMatching {
                 int resBondedAtNum = partialMatching[bondedTemplateAtNum];
                 
                 double templateDist = templateDistanceMatrix[templateAtNum][bondedTemplateAtNum];
-                double resDist = residueDistanceMatrix[resAtNum][resBondedAtNum];
+                double resDist = 0;
+
+                if(resAtNum >= 0 && resBondedAtNum >= 0)
+                    resDist = residueDistanceMatrix[resAtNum][resBondedAtNum];
                 
                 double distDiff = templateDist - resDist;
                 ans += distDiff*distDiff;

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplate.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplate.java
@@ -23,25 +23,25 @@ public class ResidueTemplate implements Serializable {
     //or whenever we want to evaluate its energy (except by an ab initio method that takes only element 
     //types and coordinates)
     //We will also need these templates to mutate from one type to another
-    
+
     //any of the information below can be null (i.e., not provided), but if so 
     //then attempts to call it will produce an error
-    
-    
+
+
     public String name;//e.g. ARG
-    
+
     //"standard" residue
     //info from here will mostly be copied into any residue in the structure to which this template is assigned
     //(charges, standardized atom names, bonds, etc.)
     public Residue templateRes;
-    
+
     //dihedral information
     public int numDihedrals = 0;
     public int dihedral4Atoms[][];//for each dihedral, list of 4 atoms defining it
     //these are indices in all our atom-wise arrays
     public ArrayList<ArrayList<Integer>> dihedralMovingAtoms;//list of atoms that move for each dihedral
-    
-    
+
+
     // Rotameric information for this residue template. ResidueTemplate supports both backbone dependent and backbone independent rotamer libraries.
     // PGC 2015: If backbone dependent rotamer libraries are used, the number of rotamers is dependent on the backbone dihedrals.
     // Dimensions: (# phi increments)x(# psi increments)
@@ -55,23 +55,23 @@ public class ResidueTemplate implements Serializable {
     // Resolution of phi and psi backbone dihedrals in the backbone dependent rotamer library. For example, in the Dunbrack rotamer library the resolution is 10. 
     public double phiPsiResolution = -1;
 
-	public ResidueTemplate(Residue res, String name){
+    public ResidueTemplate(Residue res, String name){
         //initializes only with info from a template file.  res won't even have coordinates yet
         templateRes = res;
         this.name = name;
     }
-    
+
     //information on dihedrals
     public int[] getDihedralDefiningAtoms(int dihedralNum){
         //numbers (indices among the atoms in this template) of the 4 atoms defining the dihedral
-    	return dihedral4Atoms[dihedralNum];
+        return dihedral4Atoms[dihedralNum];
     }
-    
+
     public ArrayList<Integer> getDihedralRotatedAtoms(int dihedralNum){
         //the atoms that actually move (including the 4th of the dihedral-defining atoms)
         return dihedralMovingAtoms.get(dihedralNum);
     }
-    
+
     void computeDihedralMovingAtoms(){
         //compute what atoms move when a dihedral is changed
         //Compute from dihedral4Atoms, and write answer in dihedralMovingAtoms
@@ -81,45 +81,45 @@ public class ResidueTemplate implements Serializable {
         //or atom 1 or to another residue,
         //then the dihedral can't move freely, and we return an error.  
         dihedralMovingAtoms = new ArrayList<>();
-        
+
         for(int dihedNum=0; dihedNum<numDihedrals; dihedNum++){
-            
+
             ArrayList<Integer> movingAtoms = new ArrayList<>();//indices of atoms that move (in templateRes.atoms)
             Atom atom2 = templateRes.atoms.get(dihedral4Atoms[dihedNum][1]);
             Atom atom3 = templateRes.atoms.get(dihedral4Atoms[dihedNum][2]);
-            
+
             for(Atom atomBeyond : atom3.bonds){
                 if(atomBeyond!=atom2){//atom 2 of dihedral doesn't move
-                    
+
                     movingAtomsDFS( atomBeyond, movingAtoms, dihedral4Atoms[dihedNum]);
                     //search recursively for other moving atoms
                 }
             }
-            
+
             dihedralMovingAtoms.add(movingAtoms);
         }
     }
-    
-    
+
+
     private void movingAtomsDFS(Atom atom, ArrayList<Integer> movingAtoms, int[] dihedAtoms){
         //Given an atom that moves when a dihedral is changed,
         //add it and any atoms distal to it to movingAtoms
         //dihedAtoms are the indices of the 4 atoms defining the dihedral
         if(atom==null)//atom is in another residue...this is an error
             throw new RuntimeException("ERROR: Trying to define non-free dihedral in rotamer library (bonds to another residue)");
-        
+
         int atomIndex = templateRes.getAtomIndexByName(atom.name);
-        
+
         if(atomIndex==dihedAtoms[0] || atomIndex==dihedAtoms[1])//there is a cycle within the residue
             throw new RuntimeException("ERROR: Trying to define non-free dihedral in rotamer library (dihedral is in a ring)");
-        
+
         if(atomIndex == dihedAtoms[2])//dihedAtoms[2] doesn't move, though it is bonded to moving atoms
             return;
-        
+
         //check that we haven't already counted atom as moving (since cycles are allowed within the set of moving atoms)
         if(movingAtoms.contains(atomIndex))
             return;
-            
+
         //if we get here, atom is a new moving atom
         //add it to the list of movingAtoms, and search for atoms distal to it
         movingAtoms.add(atomIndex);
@@ -136,73 +136,84 @@ public class ResidueTemplate implements Serializable {
      * @return the angle value for the desired dihedral.
      */
     public double getRotamericDihedrals(double phi, double psi, int rotNum, int dihedralNum){
-                
-                if(Double.isNaN(phi) || Double.isNaN(psi)){//dihedrals not defined for this residue
-                    if(numberOfPhiPsiBins > 1)
-                        throw new RuntimeException("ERROR: Can't use Dunbrack library on residues w/o phi/psi defined");
-                    
-                    return rotamericDihedrals[0][0][rotNum][dihedralNum];
-                }
 
-		// Under the dunbrack rotamer library, backbone dependent rotamers have a resolution of 10 degrees, 
-		//    while in backbone-independent rotamer libraries they have a resolution of 360.    		
-		//  Therefore, we round to the closest "bin" and add numberOfPhiPsiBins/2 (to make all numbers positive)
-		int phiBin = (int)(Math.round(phi/this.phiPsiResolution)) + this.numberOfPhiPsiBins/2;
-		int psiBin = (int)(Math.round(psi/this.phiPsiResolution)) + this.numberOfPhiPsiBins/2;
-		return rotamericDihedrals[phiBin][psiBin][rotNum][dihedralNum];
+        if(Double.isNaN(phi) || Double.isNaN(psi)){//dihedrals not defined for this residue
+            if(numberOfPhiPsiBins > 1)
+                throw new RuntimeException("ERROR: Can't use Dunbrack library on residues w/o phi/psi defined");
+
+            return rotamericDihedrals[0][0][rotNum][dihedralNum];
+        }
+
+        // Under the dunbrack rotamer library, backbone dependent rotamers have a resolution of 10 degrees, 
+        //    while in backbone-independent rotamer libraries they have a resolution of 360.    		
+        //  Therefore, we round to the closest "bin" and add numberOfPhiPsiBins/2 (to make all numbers positive)
+        int phiBin = (int)(Math.round(phi/this.phiPsiResolution)) + this.numberOfPhiPsiBins/2;
+        int psiBin = (int)(Math.round(psi/this.phiPsiResolution)) + this.numberOfPhiPsiBins/2;
+        return rotamericDihedrals[phiBin][psiBin][rotNum][dihedralNum];
 
     }
+    
+    public double getRotamericDihedrals(int rotNum, int dihedralNum){
+        return getRotamericDihedrals(0,0,rotNum,dihedralNum);
+    }
+    
     /**
      * Returns the number of rotamers for a backbone-dependent or backbone independent rotamer library.
      * @param phi The backbone phi angle, ignored if backbone independent rotamer library.
      * @param psi The backbone psi angle, ignored if backbone independent rotamer library.
      * @return The number of rotamers.
      */
+
     public int getNumRotamers(double phi, double psi){
-        
-                if(Double.isNaN(phi) || Double.isNaN(psi)){//dihedrals not defined for this residue
-                    if(numberOfPhiPsiBins > 1)
-                        throw new RuntimeException("ERROR: Can't use Dunbrack library on residues w/o phi/psi defined");
-                    
-                    return numRotamers[0][0];
-                }
-        
-        
-		// Under the dunbrack rotamer library, backbone dependent rotamers have a resolution of 10 degrees, 
-		//    while in backbone-independent rotamer libraries they have a resolution of 360.    		
-		//  Therefore, we round to the closest "bin" and add numberOfPhiPsiBins/2 (to make all numbers positive)
-		int phiBin = (int)((Math.round(phi/this.phiPsiResolution))) + this.numberOfPhiPsiBins/2;
-		int psiBin = (int)((Math.round(psi/this.phiPsiResolution))) + this.numberOfPhiPsiBins/2;
-                return this.numRotamers[phiBin][psiBin];
+
+        if(Double.isNaN(phi) || Double.isNaN(psi)){//dihedrals not defined for this residue
+            if(numberOfPhiPsiBins > 1)
+                throw new RuntimeException("ERROR: Can't use Dunbrack library on residues w/o phi/psi defined");
+
+            return numRotamers[0][0];
+        }
+
+
+        // Under the dunbrack rotamer library, backbone dependent rotamers have a resolution of 10 degrees, 
+        //    while in backbone-independent rotamer libraries they have a resolution of 360.    		
+        //  Therefore, we round to the closest "bin" and add numberOfPhiPsiBins/2 (to make all numbers positive)
+        int phiBin = (int)((Math.round(phi/this.phiPsiResolution))) + this.numberOfPhiPsiBins/2;
+        int psiBin = (int)((Math.round(psi/this.phiPsiResolution))) + this.numberOfPhiPsiBins/2;
+        return this.numRotamers[phiBin][psiBin];
     }
+    
+    public int getNumRotamers() {
+        return getNumRotamers(0,0);
+    }
+    
     /**
      * Number of "bins" for Phi/Psi angles for backbone dependent rotamer libraries. For example, in the Dunbrack library there are 37 bins.
      * @param numberOfPsiBins
      */
-	public void setNumberOfPhiPsiBins(int numberOfPhiPsiBins) {
-		this.numberOfPhiPsiBins = numberOfPhiPsiBins;
-	}
+    public void setNumberOfPhiPsiBins(int numberOfPhiPsiBins) {
+        this.numberOfPhiPsiBins = numberOfPhiPsiBins;
+    }
     /**
      * Resolution of backbone "bins" in the rotamer library. For example in a backbone independent rotamer library this should be "360". 
      * For the Dunbrack rotamer library this is 10. Set in the corresponding parser of the rotamer library. 
      * @param phiPsiResolution.
      */
     public void setRLphiPsiResolution(double phiPsiResolution) {
-		this.phiPsiResolution = phiPsiResolution;
-	}
+        this.phiPsiResolution = phiPsiResolution;
+    }
 
     /**
      * Initialize the numRotamers and rotamericDihedrals arrays to the number of bins according to each rotamer library. 
      */
-	public void initializeRotamerArrays(){
-		assert (numberOfPhiPsiBins > 0);
-    	this.numRotamers= new int [numberOfPhiPsiBins][];
-    	this.rotamericDihedrals = new double[numberOfPhiPsiBins][][][];
-    	for (int i = 0; i < numberOfPhiPsiBins; i++){
-    		this.numRotamers[i] = new int [numberOfPhiPsiBins];
-    		this.rotamericDihedrals[i] = new double[numberOfPhiPsiBins][][];
-    	}   	
-    	
+    public void initializeRotamerArrays(){
+        assert (numberOfPhiPsiBins > 0);
+        this.numRotamers= new int [numberOfPhiPsiBins][];
+        this.rotamericDihedrals = new double[numberOfPhiPsiBins][][][];
+        for (int i = 0; i < numberOfPhiPsiBins; i++){
+            this.numRotamers[i] = new int [numberOfPhiPsiBins];
+            this.rotamericDihedrals[i] = new double[numberOfPhiPsiBins][][];
+        }   	
+
     }
 
     /**
@@ -213,17 +224,23 @@ public class ResidueTemplate implements Serializable {
      * @param phiBin Bin in the rotamer array where the rotameric dihedrals will be stored. 
      * @param psiBin Bin in the rotamer array where the rotameric dihedrals will be stored. 
      */
+
     public void setNumRotamers(int numRotamers, int phiBin, int psiBin){
 
-		this.numRotamers[phiBin][psiBin] = numRotamers;
+        this.numRotamers[phiBin][psiBin] = numRotamers;
 
     }
+    
+    public void setNumRotamers(int numRotamers){
+        setNumRotamers(numRotamers,0,0);
+    }
+    
     /**
      * PGC 2015:
      * Set the number of dihedrals for this Residue type 
      */
     public void setNumDihedrals(int numDihedrals){
-    	this.numDihedrals = numDihedrals;
+        this.numDihedrals = numDihedrals;
     }
     /**
      * PGC 2015: 
@@ -232,10 +249,14 @@ public class ResidueTemplate implements Serializable {
      * @param numRotamers Number of rotamers
      * @param phiBin Bin in the rotamer array where the rotameric dihedrals will be stored. 
      * @param psiBin Bin in the rotamer array where the rotameric dihedrals will be stored. 
-     */
+     */    
     public void setRotamericDihedrals(double newRotamericDihedrals[][], int phiBin, int psiBin){
-		this.rotamericDihedrals[phiBin][psiBin] = newRotamericDihedrals;
+        this.rotamericDihedrals[phiBin][psiBin] = newRotamericDihedrals;
     }
     
+    public void setRotamericDihedrals(double newRotamericDihedrals[][]){
+        setRotamericDihedrals(newRotamericDihedrals,0,0);
+     }
+
 
 }

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
@@ -52,5 +52,9 @@ public abstract class ResidueTemplateLibrary {
         throw new RuntimeException("ERROR: template not found for residue type "+resType);
     }
     
+    protected void addResidueTemplate(ResidueTemplate template)
+    {
+    	templates.add(template);
+    }
 
 }

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
@@ -36,7 +36,7 @@ public abstract class ResidueTemplateLibrary {
 	 * @param dihedralNum The dihedral number within this rotamer.
 	 * @return
 	 */
-	public double getDihedralForRotamer(String resType, double phi, double psi,
+	public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
 			int rotNum, int dihedralNum) {
 			    return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
 			}

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
@@ -1,344 +1,47 @@
-/*
- * To change this template, choose Tools | Templates
- * and open the template in the editor.
- */
 package edu.duke.cs.osprey.restypes;
 
-import edu.duke.cs.osprey.control.EnvironmentVars;
-import edu.duke.cs.osprey.energy.forcefield.ForcefieldParams;
-import edu.duke.cs.osprey.structure.Atom;
-import edu.duke.cs.osprey.structure.Residue;
-import edu.duke.cs.osprey.tools.StringParsing;
-import java.io.BufferedReader;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
-import java.util.StringTokenizer;
 
-/**
- *
- * @author mhall44
- */
-public class ResidueTemplateLibrary {
-    //This library of residue templates defines what types of residues we can model
-    //and what flexibility and energy parameters come with each type
-    //NAMING: We assume each distinct residue (AA or otherwise) has its own name
-    //however, many residues will have multiple slightly different forms (N-terminal, etc.) 
-    //and these will share a name and a rotamer library entry
-    
-    
+public abstract class ResidueTemplateLibrary {
+
     public ArrayList<ResidueTemplate> templates = new ArrayList<>();
-    
-    public int totalNumRotamers = 0;//total number of rotamers read in from rotamer library file(s)
-    //starts at 0
-    
-    //the templates contain forcefield information like atom types, so they need to go with 
-    //a set of forcefield parameters
-    public ForcefieldParams ffParams;
-    
-    public ResidueTemplateLibrary(String[] templateFiles, ForcefieldParams fp){
-        //create a library based on template files
-        //we can then load coordinates and rotamer libraries for these templates separately, if we have these
+	
+	public ResidueTemplateLibrary() {
+	}
 
-        ffParams = fp;
-        
-        for(String fileName : templateFiles){
-            loadTemplates(fileName);
-        }
-    }
-        
-        
-    public void loadTemplates(String templateFile){//load templates from the indicated files,
-        //and add them to our list of templates
-        try {
+	public int numDihedralsForResType(String resType) {
+	    //number of free dihedrals (sidechain dihedrals for actual amino acids)
+	    return firstTemplate(resType).numDihedrals;
+	}
 
-            FileInputStream is = new FileInputStream( EnvironmentVars.getDataDir().concat(templateFile) );
-            BufferedReader bufread = new BufferedReader(new InputStreamReader(is));
+	/**
+	 * PGC 2015: 
+	 * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
+	 * @param pos 
+	 * @param resType in three letter amino acid type
+	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @return The number of rotamers.  
+	 */
+	public abstract int numRotForResType(int pos, String resType, double phi, double psi);
 
-            // Skip over first 2 lines of header info
-            bufread.readLine();
-            bufread.readLine();
-
-            while(true) {//read all the templates
-                //at the beginning of this loop, curLine is the long amino acid name,
-                //which we discard.  readTemplate will thus start reading the next line
-                ResidueTemplate newTemplate = readTemplate(bufread);
-                if(newTemplate==null)//null newTemplate means lines needed to be skipped or something
-                    break;
-                else {
-                    templates.add(newTemplate);
-                }
-            }
-            bufread.close();
-        }
-        
-        catch (FileNotFoundException e) {
-                System.out.println("ERROR: Template File Not Found: "+e);
-                e.printStackTrace();
-                System.exit(0);
-        }
-        catch (IOException e) {
-                System.out.println("ERROR reading template file: "+e);
-                e.printStackTrace();
-                System.exit(0);
-        }
-    }
-    
-    
-    private ResidueTemplate readTemplate (BufferedReader bufread) throws IOException {
-        //read a template from the BufferedReader provided (it reads a template file)
-        //null means all templates already read from file
-        
-        String curLine = bufread.readLine();
-        if(curLine==null)//file ended!
-            return null;
-        else if (curLine.length() >= 4){
-                if (curLine.substring(0,4).equalsIgnoreCase("stop")) {
-                        curLine = bufread.readLine();
-                        return null;//finished reading file!
-                }
-        }
-        // Skip blank line
-        curLine = bufread.readLine();
-        // The next line contains the 3 letter amino acid name
-        curLine = bufread.readLine();
-        String templateName = StringParsing.getToken(curLine,1);
-        
-        // Skip next 2 lines
-        curLine = bufread.readLine();
-        curLine = bufread.readLine();
-        // Now we're into the section with atoms
-        curLine = bufread.readLine();
-        // Skip the dummy atoms
-        int dumPresent = 0;
-        while (StringParsing.getToken(curLine,2).equalsIgnoreCase("DUMM")) {
-                dumPresent++;
-                curLine = bufread.readLine();
-        }
-        dumPresent++; // to adjust for 0-based
-        
-        ArrayList<Atom> atomList = new ArrayList<>();
-        
-        while (!StringParsing.getToken(curLine,2).equals("")) {//read info on atoms
-                String atomName = StringParsing.getToken(curLine,2);
-                Atom at = new Atom (atomName);
-                
-                at.forceFieldType = StringParsing.getToken(curLine,3);
-                at.type = ffParams.atomTypeToInt(at.forceFieldType);
-                at.charge = (double) (new Double(StringParsing.getToken(curLine,11)).doubleValue());
-
-                //the template only records bonds within the residue
-                
-                //KER: The first atom is bonded to a dummy atom so we can't include that
-                //KER: in the bond list, so check atom is >= 0
-                int atomBondedTo = ((new Integer(StringParsing.getToken(curLine,5))).intValue())-dumPresent;
-                if(atomBondedTo >=0){
-                        at.addBond(atomList.get(atomBondedTo));
-                }
-                
-                atomList.add(at);
-                curLine = bufread.readLine();  // read next line
-        }
-
-        
-        Residue templateRes = new Residue(atomList,null,templateName,null);//no molecule or coordinates yets
-
-
-        do {//we expect one or more blank lines before the LOOP and IMPROPER records
-            curLine = bufread.readLine();
-        }
-        while(curLine.trim().isEmpty());
-        
-        //KER: Read LOOP data if any
-        if (curLine.length() >= 4){
-                if(StringParsing.getToken(curLine, 1).equalsIgnoreCase("LOOP")){
-                        curLine = bufread.readLine();
-                        while(!StringParsing.getToken(curLine,2).equals("")){
-                                //find atom1
-                                for(Atom a : atomList){
-                                        if(a.name.equalsIgnoreCase(StringParsing.getToken(curLine,1))){
-                                                //find atom2
-                                                for(Atom b : atomList){
-                                                        if(b.name.equalsIgnoreCase(StringParsing.getToken(curLine,2))){
-                                                                a.addBond(b);
-                                                        }
-                                                }
-                                        }
-                                }
-                                curLine = bufread.readLine();
-                        }
-                }
-        }
-        
-        //at this point templateRes has all its intra-res bonds all marked
-        templateRes.intraResBondsMarked = true;
-
-        // Eventually we might want to be able to handle the improper
-        //  torsions listed here
-
-        
-        // Read until the end of the residue
-        boolean atDone = false;
-        if (curLine.length() >= 4)
-                atDone = curLine.substring(0,4).equalsIgnoreCase("done");
-        else
-                atDone = false;
-        while (!atDone) {
-                curLine = bufread.readLine();
-                if (curLine.length() >= 4)
-                        atDone = curLine.substring(0,4).equalsIgnoreCase("done");
-        }
-        
-        
-        ResidueTemplate newTemplate = new ResidueTemplate(templateRes,templateName);
-        return newTemplate;
-    }
-    
-    
-    
-    public void loadTemplateCoords(String fileName){
-        //load coordinates for templates, given in the following file
-        //they should match templates that are already loaded (same residue and atom names)
-        //we will need coordinates for any residue type that we mutate to
-        
-        try {
-                
-            FileInputStream is = new FileInputStream( EnvironmentVars.getDataDir().concat(fileName) );
-            BufferedReader bufread = new BufferedReader(new InputStreamReader(is));
-            String curLine = null, tmpName = null;
-            int tmpCtr = 0;
-
-            curLine = bufread.readLine();
-            while ( curLine.startsWith("#") ){
-                    curLine = bufread.readLine();
-            }
-            boolean foundRes = false;
-            boolean foundAtom = false;
-            while (curLine != null ){
-                    String resName = StringParsing.getToken(curLine,1);
-                    int numAtoms = new Integer(StringParsing.getToken(curLine,2)); 
-                    foundRes = false;
-                    for(ResidueTemplate template : templates){//find the template to assign these coordinates to
-            
-                        if(template.name.equalsIgnoreCase(resName)){//found it
-                            
-                                Residue r = template.templateRes;
-                                if(r.atoms.size()!=numAtoms)
-                                    throw new RuntimeException("ERROR: Coords file has wrong number of atoms for "+r.fullName);
-
-                                r.coords = new double[3*numAtoms];//allocate coordinates
-
-                                foundRes = true;
-                                for(int i=0;i<numAtoms;i++){
-                                        curLine = bufread.readLine();
-                                        //Find the current atom in the residue
-                                        foundAtom = false;
-                                        for(int atNum=0; atNum<numAtoms; atNum++){
-                                                Atom at = r.atoms.get(atNum);
-                                                if(at.name.equalsIgnoreCase(StringParsing.getToken(curLine,1))){
-                                                        foundAtom = true;
-                                                        //read coordinates for this atom
-                                                        double x = new Double(StringParsing.getToken(curLine,2));
-                                                        double y = new Double(StringParsing.getToken(curLine,3)); 
-                                                        double z = new Double(StringParsing.getToken(curLine,4));
-                                                        r.coords[3*atNum] = x;
-                                                        r.coords[3*atNum+1] = y;
-                                                        r.coords[3*atNum+2] = z;
-                                                        break;
-                                                }
-                                        }
-                                        if(!foundAtom){
-                                                System.out.println("Residue coord and forcefield templates did not match up.");
-                                                System.exit(0);
-                                                //Possible issue: first occurrence of this name in the template residues is the wrong form for these coordinates?
-                                        }		
-                                }
-                                break;
-                        }
-                    }
-                    //If we didn't find a match we need to get rid of those 
-                    //lines from the file
-                    if(!foundRes){
-                            for(int i=0; i<numAtoms;i++){
-                                    curLine=bufread.readLine();
-                            }
-                    }
-                    //Read to catch the ENDRES line and then
-                    //get the start of the next AA
-                    curLine = bufread.readLine();
-                    curLine = bufread.readLine();
-            }
-            bufread.close();
-        }
-        catch (FileNotFoundException e) {
-                System.out.println("ERROR: Template File Not Found: "+e);
-                e.printStackTrace();
-                System.exit(0);
-        }
-        catch (IOException e) {
-                System.out.println("ERROR reading template file: "+e);
-                e.printStackTrace();
-                System.exit(0);
-        }
-        
-    }
-    
-    /** 
-     * PGC 2015: Supporting two rotamer libraries right now, Lovell and Dunbrack backbone dependent rotamers.
-     * load rotamer information into templates.
-     * @param filename for Lovell-style or Dunbrack Rotamer Library.
-     * @param backbone_dependent_rotamers Use Dunbrack Rotamer Library? 
-     */
-    public void loadRotamerLibrary(String fileName, boolean dunbrack_backbone_dependent_rotamers){
-
-        if(dunbrack_backbone_dependent_rotamers){
-        	RotamerLibraryReader.readDunbrackRotamerLibraryForResiduePosition(fileName, this);
-        }
-        else{
-        	RotamerLibraryReader.readRotLibrary(fileName, this);
-        }
-        //read volume here too?
-        
-    }
-    
-    
-    
-    //Functions to get templates and information from them    
-    public int numDihedralsForResType(String resType){
-        //number of free dihedrals (sidechain dihedrals for actual amino acids)
-        return firstTemplate(resType).numDihedrals;
-    }
-
-    /**
-     * PGC 2015: 
-     * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
-     * @param resType in three letter amino acid type
-     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @return The number of rotamers.  
-     */
-    public int numRotForResType(String resType, double phi, double psi){
-        return firstTemplate(resType).getNumRotamers(phi, psi);
-    }
-    /**
-     * PGC 2015:
-     * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
-     * 
-     * @param resType in three letter amino acid type
-     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param rotNum The rotamer number within this residue type.
-     * @param dihedralNum The dihedral number within this rotamer.
-     * @return
-     */
-    public double getDihedralForRotamer(String resType, double phi, double psi, int rotNum, int dihedralNum){
-        return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
-    } 
-
-    
-    public ResidueTemplate firstTemplate(String resType){
+	/**
+	 * PGC 2015:
+	 * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
+	 * 
+	 * @param resType in three letter amino acid type
+	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param rotNum The rotamer number within this residue type.
+	 * @param dihedralNum The dihedral number within this rotamer.
+	 * @return
+	 */
+	public double getDihedralForRotamer(String resType, double phi, double psi,
+			int rotNum, int dihedralNum) {
+			    return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
+			}
+	
+    protected ResidueTemplate firstTemplate(String resType){
         //get the first template with the given residue type 
         //templates with the same type will all have the same rotamers, etc.
         //so this is good for looking up things like that
@@ -349,50 +52,5 @@ public class ResidueTemplateLibrary {
         throw new RuntimeException("ERROR: template not found for residue type "+resType);
     }
     
-    
-    public ResidueTemplate getTemplateForMutation(String resTypeName, Residue res, boolean errorIfNone){
-        //We want to mutate res to type resTypeName.  Get the appropriate template.
-        //Currently only one template capable of being mutated to (i.e., having coordinates)
-        //is available for each residue type.  If this changes update here!
-        for(ResidueTemplate template : templates){
-            if(template.name.equalsIgnoreCase(resTypeName)){
-                if(template.templateRes.coords!=null){
-                    //we have coordinates for templateRes, so can mutate to it
-                    return template;
-                }
-            }
-        }
-        
-        if(errorIfNone){//actually trying to mutate...throw an error if can't get a mutation
-            throw new RuntimeException("ERROR: Couldn't find a template for mutating "+res.fullName
-                    +" to "+resTypeName);
-        }
-        else//just checking if template available for mutation...return null to indicate not possible
-            return null;
-    }
-    
-    
-    public void makeDAminoAcidTemplates(){
-        //Make a D-amino acid template for every standard L-amino acid template in the library
-        //This lets us do D-amino acids without having to have separate templates
-        //A D-amino acid is just an inverted L-amino acid (including Ile and Thr,
-        //which have a second chiral center)
-        ArrayList<ResidueTemplate> DTemplates = new ArrayList<>();
-        
-        for(ResidueTemplate template : templates){
-            
-            if( DAminoAcidHandler.isStandardLAminoAcid(template.name) ){
-                //template recognized as standard L-amino acid
-                
-                DTemplates.add( DAminoAcidHandler.makeDTemplate(template) );
-            }
-        }
-        
-        templates.addAll(DTemplates);
-    }
-    
-    
 
-    
 }
-

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
@@ -5,42 +5,48 @@ import java.util.ArrayList;
 public abstract class ResidueTemplateLibrary {
 
     public ArrayList<ResidueTemplate> templates = new ArrayList<>();
-	
-	public ResidueTemplateLibrary() {
-	}
 
-	public int numDihedralsForResType(String resType) {
-	    //number of free dihedrals (sidechain dihedrals for actual amino acids)
-	    return firstTemplate(resType).numDihedrals;
-	}
+    public ResidueTemplateLibrary() {
+    }
 
-	/**
-	 * PGC 2015: 
-	 * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
-	 * @param pos 
-	 * @param resType in three letter amino acid type
-	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-	 * @return The number of rotamers.  
-	 */
-	public abstract int numRotForResType(int pos, String resType, double phi, double psi);
+    public int numDihedralsForResType(String resType) {
+        //number of free dihedrals (sidechain dihedrals for actual amino acids)
+        return firstTemplate(resType).numDihedrals;
+    }
 
-	/**
-	 * PGC 2015:
-	 * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
-	 * 
-	 * @param resType in three letter amino acid type
-	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-	 * @param rotNum The rotamer number within this residue type.
-	 * @param dihedralNum The dihedral number within this rotamer.
-	 * @return
-	 */
-	public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
-			int rotNum, int dihedralNum) {
-			    return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
-			}
-	
+    /**
+     * PGC 2015: 
+     * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
+     * @param pos 
+     * @param resType in three letter amino acid type
+     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+     * @return The number of rotamers.  
+     */
+    public abstract int numRotForResType(int pos, String resType, double phi, double psi);
+
+    /**
+     * PGC 2015:
+     * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
+     * 
+     * @param resType in three letter amino acid type
+     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+     * @param rotNum The rotamer number within this residue type.
+     * @param dihedralNum The dihedral number within this rotamer.
+     * @return
+     */
+    public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
+            int rotNum, int dihedralNum) {
+        return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
+    }
+    public double getDihedralForRotamer(int pos, String resType, int rotNum, int dihedralNum) {
+        return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
+    }
+    public double getDihedralForRotamer(String resType, int rotNum, int dihedralNum) {
+        return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
+    }
+
     protected ResidueTemplate firstTemplate(String resType){
         //get the first template with the given residue type 
         //templates with the same type will all have the same rotamers, etc.
@@ -51,10 +57,10 @@ public abstract class ResidueTemplateLibrary {
         }
         throw new RuntimeException("ERROR: template not found for residue type "+resType);
     }
-    
+
     protected void addResidueTemplate(ResidueTemplate template)
     {
-    	templates.add(template);
+        templates.add(template);
     }
 
 }

--- a/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
+++ b/src/edu/duke/cs/osprey/restypes/ResidueTemplateLibrary.java
@@ -4,63 +4,63 @@ import java.util.ArrayList;
 
 public abstract class ResidueTemplateLibrary {
 
-    public ArrayList<ResidueTemplate> templates = new ArrayList<>();
+	public ArrayList<ResidueTemplate> templates = new ArrayList<>();
 
-    public ResidueTemplateLibrary() {
-    }
+	public ResidueTemplateLibrary() {
+	}
 
-    public int numDihedralsForResType(String resType) {
-        //number of free dihedrals (sidechain dihedrals for actual amino acids)
-        return firstTemplate(resType).numDihedrals;
-    }
+	public int numDihedralsForResType(String resType) {
+		//number of free dihedrals (sidechain dihedrals for actual amino acids)
+		return firstTemplate(resType).numDihedrals;
+	}
 
-    /**
-     * PGC 2015: 
-     * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
-     * @param pos 
-     * @param resType in three letter amino acid type
-     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @return The number of rotamers.  
-     */
-    public abstract int numRotForResType(int pos, String resType, double phi, double psi);
+	/**
+	 * PGC 2015: 
+	 * Returns the number of rotamers for the specified residue type, for backbone dependent or backbone independent rotamers.
+	 * @param pos 
+	 * @param resType in three letter amino acid type
+	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @return The number of rotamers.  
+	 */
+	public abstract int numRotForResType(int pos, String resType, double phi, double psi);
 
-    /**
-     * PGC 2015:
-     * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
-     * 
-     * @param resType in three letter amino acid type
-     * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
-     * @param rotNum The rotamer number within this residue type.
-     * @param dihedralNum The dihedral number within this rotamer.
-     * @return
-     */
-    public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
-            int rotNum, int dihedralNum) {
-        return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
-    }
-    public double getDihedralForRotamer(int pos, String resType, int rotNum, int dihedralNum) {
-        return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
-    }
-    public double getDihedralForRotamer(String resType, int rotNum, int dihedralNum) {
-        return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
-    }
+	/**
+	 * PGC 2015:
+	 * get ideal dihedral value for a particular rotamer of a particular residue type, for backbone dependent or backbone independent rotamers.
+	 * 
+	 * @param resType in three letter amino acid type
+	 * @param phi The backbone phi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param psi The backbone psi angle for backbone dependent rotamers; will be ignored if backbone dependent rotamer libraries are not used.
+	 * @param rotNum The rotamer number within this residue type.
+	 * @param dihedralNum The dihedral number within this rotamer.
+	 * @return
+	 */
+	public double getDihedralForRotamer(int pos, String resType, double phi, double psi,
+			int rotNum, int dihedralNum) {
+		return firstTemplate(resType).getRotamericDihedrals(phi, psi, rotNum, dihedralNum);
+	}
+	public double getDihedralForRotamer(int pos, String resType, int rotNum, int dihedralNum) {
+		return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
+	}
+	public double getDihedralForRotamer(String resType, int rotNum, int dihedralNum) {
+		return firstTemplate(resType).getRotamericDihedrals(0, 0, rotNum, dihedralNum);
+	}
 
-    protected ResidueTemplate firstTemplate(String resType){
-        //get the first template with the given residue type 
-        //templates with the same type will all have the same rotamers, etc.
-        //so this is good for looking up things like that
-        for(ResidueTemplate templ : templates){
-            if( templ.name.equalsIgnoreCase(resType) )
-                return templ;
-        }
-        throw new RuntimeException("ERROR: template not found for residue type "+resType);
-    }
+	protected ResidueTemplate firstTemplate(String resType){
+		//get the first template with the given residue type 
+		//templates with the same type will all have the same rotamers, etc.
+		//so this is good for looking up things like that
+		for(ResidueTemplate templ : templates){
+			if( templ.name.equalsIgnoreCase(resType) )
+				return templ;
+		}
+		throw new RuntimeException("ERROR: template not found for residue type "+resType);
+	}
 
-    protected void addResidueTemplate(ResidueTemplate template)
-    {
-        templates.add(template);
-    }
+	protected void addResidueTemplate(ResidueTemplate template)
+	{
+		templates.add(template);
+	}
 
 }

--- a/src/edu/duke/cs/osprey/restypes/RotamerLibraryReader.java
+++ b/src/edu/duke/cs/osprey/restypes/RotamerLibraryReader.java
@@ -25,7 +25,7 @@ public class RotamerLibraryReader implements Serializable {
 	
 	//Read in all of the rotamers for all amino acids from the rotFilename file
         //into the ResidueTemplateLibrary
-	public static void readRotLibrary(String rotFilename, ResidueTemplateLibrary templateLib) {
+	public static void readRotLibrary(String rotFilename, GenericResidueTemplateLibrary templateLib) {
             
             try {
                 
@@ -222,7 +222,7 @@ public class RotamerLibraryReader implements Serializable {
 	 *    the template library templateLib. 
 	 *  @param templateLib The library of residue templates.
 	 */
-	public static void readDunbrackRotamerLibraryForResiduePosition(String rotFilename, ResidueTemplateLibrary templateLib){
+	public static void readDunbrackRotamerLibraryForResiduePosition(String rotFilename, GenericResidueTemplateLibrary templateLib){
 
 		// Dunbrack has rotamers in increments of 10 for phi and psi.
 		double dunbrackResolution = 10;

--- a/src/edu/duke/cs/osprey/structure/Molecule.java
+++ b/src/edu/duke/cs/osprey/structure/Molecule.java
@@ -6,6 +6,8 @@ package edu.duke.cs.osprey.structure;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  *
@@ -14,6 +16,7 @@ import java.util.ArrayList;
 public class Molecule implements Serializable {
     
     public ArrayList<Residue> residues = new ArrayList<>();
+    private Map<Integer,ArrayList<Residue>> alternates = new HashMap<>();
     
     //also might have secondary structure elements...
 
@@ -39,6 +42,13 @@ public class Molecule implements Serializable {
         //Add a residue to the end of the molecule
         res.indexInMolecule = residues.size();
         residues.add(res);
+    }
+    
+    public void addAlternate(int resIndex, Residue res)
+    {
+        if(!alternates.containsKey(resIndex))
+            alternates.put(resIndex, new ArrayList<Residue>());
+        alternates.get(resIndex).add(res);
     }
     
     public void deleteResidue(int resIndex){

--- a/src/edu/duke/cs/osprey/structure/PDBRotamerReader.java
+++ b/src/edu/duke/cs/osprey/structure/PDBRotamerReader.java
@@ -1,0 +1,244 @@
+package edu.duke.cs.osprey.structure;
+
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import edu.duke.cs.osprey.control.EnvironmentVars;
+import edu.duke.cs.osprey.restypes.ResidueTemplate;
+import edu.duke.cs.osprey.tools.Protractor;
+
+/***
+ * Simple class to read in a PDB file and spit out rotamers for 
+ * both the main conformation and alternates, if any.
+ * @author JJ
+ *
+ */
+public class PDBRotamerReader {
+    
+
+    public static void addAlternates(Molecule m, String PDBFileName)
+    {
+        try {
+
+            FileInputStream is = new FileInputStream(PDBFileName);
+            BufferedReader bufread = new BufferedReader(new InputStreamReader(is));
+
+            String curLine = bufread.readLine();
+
+            ArrayList<String> helixStarts = new ArrayList<>();//Residues where helices start
+            ArrayList<String> helixEnds = new ArrayList<>();//Residues where they end
+            ArrayList<Character> helixChains = new ArrayList<>();
+            ArrayList<String> sheetStarts = new ArrayList<>();
+            ArrayList<String> sheetEnds = new ArrayList<>();
+            ArrayList<Character> sheetChains = new ArrayList<>();
+            //So for each helix/sheet, 
+            //we record its starting and ending residue numbers and its chain
+
+
+            ArrayList<Atom> curResAtoms = new ArrayList<>();
+            Map<Character, ArrayList<Atom>> alternateAtoms = new HashMap<>();
+            ArrayList<double[]> curResCoords = new ArrayList<>();//coordinates for these atoms
+            Map<Character, ArrayList<double[]>> alternateResidueCoords = new HashMap<>();
+            String curResFullName = "NONE";
+
+            while(curLine!=null){
+
+                // First pad line to 80 characters
+                int lineLen = curLine.length();
+                for (int i=0; i < (80-lineLen); i++)
+                    curLine += " ";
+                System.out.println("Line: "+curLine);
+
+                if ( (curLine.regionMatches(true,0,"ATOM  ",0,6)) || (curLine.regionMatches(true,0,"HETATM",0,6)) ){
+
+                    char alt = curLine.charAt(16);//This specifies which alternate the atom is (space if not an alternate)
+                    
+
+                    if(alt != ' ')
+                    {
+                        String fullResName = fullResidueName(curLine);
+                        int residueIndex = getResidueIndex(curLine);
+                        System.out.println("Residue "+residueIndex+", alternate "+alt);
+                        
+                        if( (!fullResName.equalsIgnoreCase(curResFullName)) && !curResAtoms.isEmpty() ){
+
+                            
+
+                            for(char c: alternateAtoms.keySet())
+                            {
+                                if(alternateAtoms.get(c).size() > 0)
+                                {
+                                    Residue alternateConformation = new Residue(alternateAtoms.get(c), 
+                                            alternateResidueCoords.get(c), curResFullName, m);
+                                    try
+                                    {
+                                        boolean success = alternateConformation.assignTemplate();
+                                        System.out.println("Template assignment succeeded?:"+success);
+                                        if(!success)
+                                        {
+                                            System.out.println("Assignment failed.");
+                                            alternateConformation.assignTemplate();
+                                            continue;
+                                        }
+                                        double[] dihedrals = computeDihedrals(alternateConformation);
+                                        m.addAlternate(residueIndex, alternateConformation);
+                                    }
+                                    catch (Exception e)
+                                    {
+                                        e.printStackTrace();
+                                    }
+
+
+                                }
+                                alternateAtoms.put(c, new ArrayList<>());
+                                alternateResidueCoords.put(c,new ArrayList<>());
+                            }
+
+                            curResAtoms = new ArrayList<>();
+                            curResCoords = new ArrayList<>();
+                        }
+
+                        curResFullName = fullResName;
+
+                        readAtom(curLine,curResAtoms,curResCoords);
+                        if(!alternateAtoms.containsKey(alt))
+                        {
+                            alternateAtoms.put(alt, new ArrayList<>());
+                            alternateResidueCoords.put(alt, new ArrayList<>());
+                        }
+                        readAtom(curLine,alternateAtoms.get(alt),alternateResidueCoords.get(alt));
+                        System.out.println("Added atoms to "+alt+":");
+                        System.out.println(alternateAtoms.get(alt));
+                        System.out.println(alternateResidueCoords.get(alt));
+
+                    }
+                }
+
+
+                curLine = bufread.readLine(); 
+            }
+
+            //make last residue
+            if( ! curResAtoms.isEmpty() ){
+                Residue newRes = new Residue( curResAtoms, curResCoords, curResFullName, m );
+                m.appendResidue(newRes);
+            }
+
+
+
+            bufread.close();  // close the buffer
+
+        }
+        catch(Exception e){
+            System.err.println(e.getMessage());
+            e.printStackTrace();
+        }
+
+
+    }
+    
+    private static double[][][] getDihedralAtomCoords(Residue r)
+    {
+        ResidueTemplate template = r.template;
+        if(template == null)
+            System.out.println("Bug?");
+        int numDihedrals = template.numDihedrals;
+
+        double[][][] coords = new double[numDihedrals][4][3];
+        int[][] dihedralAtoms = template.dihedral4Atoms;
+        for(int dihedralIndex = 0; dihedralIndex < numDihedrals; dihedralIndex++)
+        {
+            for(int atomIndex = 0; atomIndex < dihedralAtoms[dihedralIndex].length; atomIndex++)
+            {
+                Atom a = r.atoms.get(dihedralAtoms[dihedralIndex][atomIndex]);
+                double[] atomicCoordinates = a.getCoords();
+                System.arraycopy(atomicCoordinates, 0, coords[dihedralIndex][atomIndex], 0, 3);
+            }
+
+        }
+        
+        return coords;
+    }
+    
+    private static double[] computeDihedrals(Residue r)
+    {
+        ResidueTemplate template = r.template;
+        
+        double[] dihedrals = new double[r.template.numDihedrals];
+        
+        double[][][] coords = getDihedralAtomCoords(r);
+        for(int i = 0; i < coords.length; i++)
+        {
+            double dihedral = Protractor.measureDihedral(coords[i]);
+            System.out.println("Measured dihedral: "+dihedral);
+            dihedrals[i] = dihedral;
+        }
+        
+        
+        return dihedrals;
+    }
+
+    private static int getResidueIndex (String curLine) {
+        return Integer.valueOf(curLine.substring(23,26).trim());
+    }
+
+    static void readAtom(String curLine, ArrayList<Atom> atomList, ArrayList<double[]> coordList) {
+        //read an ATOM line and store it in the list of atoms and of atom coordinates
+
+        String tmpStg = curLine.substring(6,11).trim();  // Snag atom serial number
+        int modelAtomNumber = (new Integer(tmpStg)).intValue();
+        String atomName = curLine.substring(12,16).trim();  // Snag atom name
+
+        tmpStg = curLine.substring(30,38);  // Snag x coord
+        double x = (double) new Double(tmpStg).doubleValue();
+        tmpStg = curLine.substring(38,46);  // Snag y coord
+        double y = (double) new Double(tmpStg).doubleValue();
+        tmpStg = curLine.substring(46,54);  // Snag z coord
+        double z = (double) new Double(tmpStg).doubleValue();
+
+        tmpStg = curLine.substring(60,66).trim();  // Snag B-factor
+        double BFactor=0;
+        if(!tmpStg.isEmpty())
+            BFactor = (double) new Double(tmpStg).doubleValue();
+
+        String elementType = curLine.substring(76,78).trim();  // Snag atom elementType
+        // If we can't get element type from substring(76,78) snag
+        //  the first character of the atom name
+        if (elementType.equalsIgnoreCase(""))
+            elementType = getEleType(curLine.substring(12,15));
+
+        Atom newAtom = new Atom(atomName, elementType, BFactor, modelAtomNumber);
+        double coords[] = new double[] {x,y,z};
+        atomList.add(newAtom);
+        coordList.add(coords);
+    }
+
+    // This function pulls the element type from
+    //  the atom name
+    private static String getEleType(String str){
+
+        int start=0, end=-1;
+        int i=0;
+        while( (str.charAt(i)==' ') || ((str.charAt(i)>='0') && (str.charAt(i)<='9')) ) {
+            i++;
+        }
+        start = i;
+        end = i++;
+        if (i<str.length())
+            if((str.charAt(i)>='a') && (str.charAt(i)<='z'))
+                end = i;
+        return(str.substring(start,end+1));
+    }
+
+
+
+    //parsing ATOM lines from a PDB file
+    static String fullResidueName(String line){
+        return line.substring(17,27);
+    }
+
+}

--- a/src/edu/duke/cs/osprey/structure/Residue.java
+++ b/src/edu/duke/cs/osprey/structure/Residue.java
@@ -10,7 +10,7 @@ import edu.duke.cs.osprey.energy.forcefield.ForcefieldParams;
 import edu.duke.cs.osprey.restypes.HardCodedResidueInfo;
 import edu.duke.cs.osprey.restypes.ResTemplateMatching;
 import edu.duke.cs.osprey.restypes.ResidueTemplate;
-import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import edu.duke.cs.osprey.restypes.GenericResidueTemplateLibrary;
 import edu.duke.cs.osprey.tools.StringParsing;
 import edu.duke.cs.osprey.tools.VectorAlgebra;
 import java.io.Serializable;
@@ -120,7 +120,7 @@ public class Residue implements Serializable {
         //return if successful or not
         
         //we'll use the default ResidueTemplateLibrary (from EnvironmentVars)
-        ResidueTemplateLibrary templateLib = EnvironmentVars.resTemplates;
+        GenericResidueTemplateLibrary templateLib = EnvironmentVars.resTemplates;
         
         //first see if there are any templates matching this name
         ArrayList<ResidueTemplate> templCandidates = new ArrayList<>();

--- a/src/edu/duke/cs/osprey/tests/TestGenerateRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/tests/TestGenerateRotamerLibrary.java
@@ -1,0 +1,31 @@
+package edu.duke.cs.osprey.tests;
+
+import edu.duke.cs.osprey.control.ConfigFileParser;
+import edu.duke.cs.osprey.control.EnvironmentVars;
+import edu.duke.cs.osprey.control.GMECFinder;
+import edu.duke.cs.osprey.restypes.PositionSpecificRotamerLibrary;
+
+public class TestGenerateRotamerLibrary {
+    
+    public static void main(String[] args)
+    {
+        // Init Environment for test
+        initEnvironmentVariables();
+        
+        String PDBFileLocation = "test/4NPD/4NPD.pdb";
+        
+        PositionSpecificRotamerLibrary.generateLibraryFromPDB(PDBFileLocation);
+    }
+    
+    private static void initEnvironmentVariables()
+    {
+        EnvironmentVars.assignTemplatesToStruct = true;
+        EnvironmentVars.resTemplates = null;
+        
+        String[] testArgs = new String[]{"-c", "test/4NPD/KStar.cfg", "Dummy command", "test/4NPD/DEE.cfg", "test/4NPD/System.cfg"};
+        ConfigFileParser cfp = new ConfigFileParser(testArgs);//args 1, 3+ are configuration files
+        cfp.loadData();
+        GMECFinder gf = new GMECFinder(cfp);
+    }
+
+}

--- a/src/edu/duke/cs/osprey/tests/TestGenerateRotamerLibrary.java
+++ b/src/edu/duke/cs/osprey/tests/TestGenerateRotamerLibrary.java
@@ -4,6 +4,7 @@ import edu.duke.cs.osprey.control.ConfigFileParser;
 import edu.duke.cs.osprey.control.EnvironmentVars;
 import edu.duke.cs.osprey.control.GMECFinder;
 import edu.duke.cs.osprey.restypes.PositionSpecificRotamerLibrary;
+import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
 
 public class TestGenerateRotamerLibrary {
     
@@ -14,7 +15,7 @@ public class TestGenerateRotamerLibrary {
         
         String PDBFileLocation = "test/4NPD/4NPD.pdb";
         
-        PositionSpecificRotamerLibrary.generateLibraryFromPDB(PDBFileLocation);
+        ResidueTemplateLibrary library = PositionSpecificRotamerLibrary.generateLibraryFromPDB(PDBFileLocation);
     }
     
     private static void initEnvironmentVariables()

--- a/src/edu/duke/cs/osprey/tests/TestPositionSpecificGMEC.java
+++ b/src/edu/duke/cs/osprey/tests/TestPositionSpecificGMEC.java
@@ -1,0 +1,46 @@
+package edu.duke.cs.osprey.tests;
+
+import org.junit.Test;
+import edu.duke.cs.osprey.confspace.SearchProblem;
+import edu.duke.cs.osprey.control.ConfigFileParser;
+import edu.duke.cs.osprey.control.EnvironmentVars;
+import edu.duke.cs.osprey.control.GMECFinder;
+import edu.duke.cs.osprey.restypes.PositionSpecificRotamerLibrary;
+import edu.duke.cs.osprey.restypes.ResidueTemplateLibrary;
+import junit.framework.TestCase;
+
+public class TestPositionSpecificGMEC extends TestCase {
+
+    ConfigFileParser cfp;
+    String PDBFileLocation = "test/4NPD/4NPD.pdb";
+    protected void setUp () throws Exception {
+        super.setUp();
+        
+        EnvironmentVars.assignTemplatesToStruct = true;
+        EnvironmentVars.resTemplates = null;
+        
+        String[] testArgs = new String[]{"-c", "test/4NPD/KStar.cfg", "Dummy command", "test/4NPD/DEE.cfg", "test/4NPD/System.cfg"};
+        cfp = new ConfigFileParser(testArgs);//args 1, 3+ are configuration files
+        cfp.loadData();
+    }
+
+    protected void tearDown () throws Exception {
+        super.tearDown();
+    }
+    
+    @Test
+    public void testLoadPDBRotamers() throws Exception
+    {
+        ResidueTemplateLibrary library = PositionSpecificRotamerLibrary.generateLibraryFromPDB(PDBFileLocation);
+    }
+    
+    @Test
+    public void testFindAlternateGMEC() throws Exception
+    {
+        ResidueTemplateLibrary library = PositionSpecificRotamerLibrary.generateLibraryFromPDB(PDBFileLocation);
+        GMECFinder gf = new GMECFinder(cfp);
+        gf.calcGMEC();
+    }
+
+
+}

--- a/src/edu/duke/cs/osprey/tests/UnitTestSuite.java
+++ b/src/edu/duke/cs/osprey/tests/UnitTestSuite.java
@@ -12,6 +12,11 @@ import java.io.IOException;
  *
  * @author mhall44
  */
+
+/* TODO:
+ * Get this running as a separate class. There's no reason to have to invoke it with all the other
+ * parameters from the command line.
+ */
 public class UnitTestSuite {
     //Suite of all unit tests to run
     //can be good to check that we didn't break something
@@ -47,6 +52,11 @@ public class UnitTestSuite {
         ConfSearchTests.testExhaustive(false, false);
         ConfSearchTests.testExhaustive(false, true);
         ConfSearchTests.testExhaustive(true, false);
+    }
+    
+    public static void main(String[] args)
+    {
+        runAllTests();
     }
     
 }

--- a/test/4NPD/4NPD.pdb
+++ b/test/4NPD/4NPD.pdb
@@ -1,0 +1,3182 @@
+HEADER    PROTEIN BINDING                         21-NOV-13   4NPD              
+TITLE     HIGH-RESOLUTION STRUCTURE OF C DOMAIN OF STAPHYLOCOCCAL PROTEIN A AT  
+TITLE    2 CRYOGENIC TEMPERATURE                                                
+COMPND    MOL_ID: 1;                                                            
+COMPND   2 MOLECULE: IMMUNOGLOBULIN G-BINDING PROTEIN A;                        
+COMPND   3 CHAIN: A;                                                            
+COMPND   4 FRAGMENT: UNP RESIDUES 270-327;                                      
+COMPND   5 SYNONYM: IGG-BINDING PROTEIN A, STAPHYLOCOCCAL PROTEIN A;            
+COMPND   6 ENGINEERED: YES;                                                     
+COMPND   7 OTHER_DETAILS: C DOMAIN OF STAPHYLOCOCCAL PROTEIN A                  
+SOURCE    MOL_ID: 1;                                                            
+SOURCE   2 ORGANISM_SCIENTIFIC: STAPHYLOCOCCUS AUREUS;                          
+SOURCE   3 ORGANISM_TAXID: 1280;                                                
+SOURCE   4 STRAIN: 8325-4;                                                      
+SOURCE   5 GENE: PROTEIN A, SPA;                                                
+SOURCE   6 EXPRESSION_SYSTEM: ESCHERICHIA COLI;                                 
+SOURCE   7 EXPRESSION_SYSTEM_TAXID: 469008;                                     
+SOURCE   8 EXPRESSION_SYSTEM_STRAIN: BL21(DE3);                                 
+SOURCE   9 EXPRESSION_SYSTEM_VECTOR_TYPE: PLASMID;                              
+SOURCE  10 EXPRESSION_SYSTEM_PLASMID: PAED4                                     
+KEYWDS    SPA, THREE-HELIX BUNDLE, CONFORMATIONAL HETEROGENEITY, RAPIDLY        
+KEYWDS   2 UNFOLDING AND FOLDING, RUF, ANTIBODY BINDING, ANTIBODY, TNFR1, VON   
+KEYWDS   3 WILLEBRAND FACTOR, PROTEIN BINDING                                   
+EXPDTA    X-RAY DIFFRACTION                                                     
+AUTHOR    L.N.DEIS,C.W.PEMBLE IV,T.G.OAS,J.S.RICHARDSON,D.C.RICHARDSON          
+REVDAT   2   22-OCT-14 4NPD    1       JRNL                                     
+REVDAT   1   08-OCT-14 4NPD    0                                                
+JRNL        AUTH   L.N.DEIS,C.W.PEMBLE,Y.QI,A.HAGARMAN,D.C.RICHARDSON,          
+JRNL        AUTH 2 J.S.RICHARDSON,T.G.OAS                                       
+JRNL        TITL   MULTISCALE CONFORMATIONAL HETEROGENEITY IN STAPHYLOCOCCAL    
+JRNL        TITL 2 PROTEIN A: POSSIBLE DETERMINANT OF FUNCTIONAL PLASTICITY.    
+JRNL        REF    STRUCTURE                     V.  22  1467 2014              
+JRNL        REFN                   ISSN 0969-2126                               
+JRNL        PMID   25295398                                                     
+JRNL        DOI    10.1016/J.STR.2014.08.014                                    
+REMARK   2                                                                      
+REMARK   2 RESOLUTION.    0.90 ANGSTROMS.                                       
+REMARK   3                                                                      
+REMARK   3 REFINEMENT.                                                          
+REMARK   3   PROGRAM     : PHENIX (PHENIX.REFINE: DEV_1664)                     
+REMARK   3   AUTHORS     : PAUL ADAMS,PAVEL AFONINE,VINCENT CHEN,IAN            
+REMARK   3               : DAVIS,KRESHNA GOPAL,RALF GROSSE-                     
+REMARK   3               : KUNSTLEVE,LI-WEI HUNG,ROBERT IMMORMINO,              
+REMARK   3               : TOM IOERGER,AIRLIE MCCOY,ERIK MCKEE,NIGEL            
+REMARK   3               : MORIARTY,REETAL PAI,RANDY READ,JANE                  
+REMARK   3               : RICHARDSON,DAVID RICHARDSON,TOD ROMO,JIM             
+REMARK   3               : SACCHETTINI,NICHOLAS SAUTER,JACOB SMITH,             
+REMARK   3               : LAURENT STORONI,TOM TERWILLIGER,PETER                
+REMARK   3               : ZWART                                                
+REMARK   3                                                                      
+REMARK   3    REFINEMENT TARGET : ML                                            
+REMARK   3                                                                      
+REMARK   3  DATA USED IN REFINEMENT.                                            
+REMARK   3   RESOLUTION RANGE HIGH (ANGSTROMS) : 0.90                           
+REMARK   3   RESOLUTION RANGE LOW  (ANGSTROMS) : 25.39                          
+REMARK   3   MIN(FOBS/SIGMA_FOBS)              : 0.000                          
+REMARK   3   COMPLETENESS FOR RANGE        (%) : 95.3                           
+REMARK   3   NUMBER OF REFLECTIONS             : 37063                          
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT.                                     
+REMARK   3   R VALUE     (WORKING + TEST SET) : 0.113                           
+REMARK   3   R VALUE            (WORKING SET) : 0.112                           
+REMARK   3   FREE R VALUE                     : 0.130                           
+REMARK   3   FREE R VALUE TEST SET SIZE   (%) : 5.220                           
+REMARK   3   FREE R VALUE TEST SET COUNT      : 1934                            
+REMARK   3                                                                      
+REMARK   3  FIT TO DATA USED IN REFINEMENT (IN BINS).                           
+REMARK   3   BIN  RESOLUTION RANGE  COMPL.    NWORK NFREE   RWORK  RFREE        
+REMARK   3     1 25.4013 -  2.1683    1.00     2693   152  0.1470 0.1604        
+REMARK   3     2  2.1683 -  1.7211    1.00     2641   144  0.1221 0.1363        
+REMARK   3     3  1.7211 -  1.5036    1.00     2646   137  0.0994 0.1268        
+REMARK   3     4  1.5036 -  1.3661    1.00     2608   152  0.0918 0.1123        
+REMARK   3     5  1.3661 -  1.2682    0.99     2614   152  0.0882 0.1180        
+REMARK   3     6  1.2682 -  1.1935    0.99     2593   136  0.0836 0.1098        
+REMARK   3     7  1.1935 -  1.1337    0.99     2596   133  0.0787 0.0846        
+REMARK   3     8  1.1337 -  1.0843    0.98     2590   143  0.0797 0.0906        
+REMARK   3     9  1.0843 -  1.0426    0.97     2522   145  0.0864 0.1042        
+REMARK   3    10  1.0426 -  1.0066    0.97     2548   145  0.0959 0.1145        
+REMARK   3    11  1.0066 -  0.9751    0.96     2540   115  0.1000 0.1287        
+REMARK   3    12  0.9751 -  0.9473    0.94     2478   150  0.1144 0.1399        
+REMARK   3    13  0.9473 -  0.9223    0.85     2215   121  0.1259 0.1433        
+REMARK   3    14  0.9223 -  0.9000    0.70     1845   109  0.1438 0.1524        
+REMARK   3                                                                      
+REMARK   3  BULK SOLVENT MODELLING.                                             
+REMARK   3   METHOD USED        : FLAT BULK SOLVENT MODEL                       
+REMARK   3   SOLVENT RADIUS     : 1.11                                          
+REMARK   3   SHRINKAGE RADIUS   : 0.90                                          
+REMARK   3   K_SOL              : NULL                                          
+REMARK   3   B_SOL              : NULL                                          
+REMARK   3                                                                      
+REMARK   3  ERROR ESTIMATES.                                                    
+REMARK   3   COORDINATE ERROR (MAXIMUM-LIKELIHOOD BASED)     : 0.040            
+REMARK   3   PHASE ERROR (DEGREES, MAXIMUM-LIKELIHOOD BASED) : 10.950           
+REMARK   3                                                                      
+REMARK   3  B VALUES.                                                           
+REMARK   3   FROM WILSON PLOT           (A**2) : 6.12                           
+REMARK   3   MEAN B VALUE      (OVERALL, A**2) : 9.38                           
+REMARK   3   OVERALL ANISOTROPIC B VALUE.                                       
+REMARK   3    B11 (A**2) : NULL                                                 
+REMARK   3    B22 (A**2) : NULL                                                 
+REMARK   3    B33 (A**2) : NULL                                                 
+REMARK   3    B12 (A**2) : NULL                                                 
+REMARK   3    B13 (A**2) : NULL                                                 
+REMARK   3    B23 (A**2) : NULL                                                 
+REMARK   3                                                                      
+REMARK   3  TWINNING INFORMATION.                                               
+REMARK   3   FRACTION: NULL                                                     
+REMARK   3   OPERATOR: NULL                                                     
+REMARK   3                                                                      
+REMARK   3  DEVIATIONS FROM IDEAL VALUES.                                       
+REMARK   3                 RMSD          COUNT                                  
+REMARK   3   BOND      :  0.013            867                                  
+REMARK   3   ANGLE     :  1.552           1178                                  
+REMARK   3   CHIRALITY :  0.087            126                                  
+REMARK   3   PLANARITY :  0.010            163                                  
+REMARK   3   DIHEDRAL  : 15.719            355                                  
+REMARK   3                                                                      
+REMARK   3  TLS DETAILS                                                         
+REMARK   3   NUMBER OF TLS GROUPS  : NULL                                       
+REMARK   3                                                                      
+REMARK   3  NCS DETAILS                                                         
+REMARK   3   NUMBER OF NCS GROUPS : NULL                                        
+REMARK   3                                                                      
+REMARK   3  OTHER REFINEMENT REMARKS: NULL                                      
+REMARK   4                                                                      
+REMARK   4 4NPD COMPLIES WITH FORMAT V. 3.30, 13-JUL-11                         
+REMARK 100                                                                      
+REMARK 100 THIS ENTRY HAS BEEN PROCESSED BY RCSB ON 26-NOV-13.                  
+REMARK 100 THE RCSB ID CODE IS RCSB083488.                                      
+REMARK 200                                                                      
+REMARK 200 EXPERIMENTAL DETAILS                                                 
+REMARK 200  EXPERIMENT TYPE                : X-RAY DIFFRACTION                  
+REMARK 200  DATE OF DATA COLLECTION        : 04-APR-13                          
+REMARK 200  TEMPERATURE           (KELVIN) : 100                                
+REMARK 200  PH                             : 7                                  
+REMARK 200  NUMBER OF CRYSTALS USED        : 1                                  
+REMARK 200                                                                      
+REMARK 200  SYNCHROTRON              (Y/N) : Y                                  
+REMARK 200  RADIATION SOURCE               : APS                                
+REMARK 200  BEAMLINE                       : 22-ID                              
+REMARK 200  X-RAY GENERATOR MODEL          : NULL                               
+REMARK 200  MONOCHROMATIC OR LAUE    (M/L) : M                                  
+REMARK 200  WAVELENGTH OR RANGE        (A) : 0.8                                
+REMARK 200  MONOCHROMATOR                  : SI(111)                            
+REMARK 200  OPTICS                         : NULL                               
+REMARK 200                                                                      
+REMARK 200  DETECTOR TYPE                  : CCD                                
+REMARK 200  DETECTOR MANUFACTURER          : MARMOSAIC 300 MM CCD               
+REMARK 200  INTENSITY-INTEGRATION SOFTWARE : HKL-2000                           
+REMARK 200  DATA SCALING SOFTWARE          : HKL-2000                           
+REMARK 200                                                                      
+REMARK 200  NUMBER OF UNIQUE REFLECTIONS   : 37877                              
+REMARK 200  RESOLUTION RANGE HIGH      (A) : 0.900                              
+REMARK 200  RESOLUTION RANGE LOW       (A) : 50.000                             
+REMARK 200  REJECTION CRITERIA  (SIGMA(I)) : 2.000                              
+REMARK 200                                                                      
+REMARK 200 OVERALL.                                                             
+REMARK 200  COMPLETENESS FOR RANGE     (%) : 97.5                               
+REMARK 200  DATA REDUNDANCY                : 6.100                              
+REMARK 200  R MERGE                    (I) : 0.06600                            
+REMARK 200  R SYM                      (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR THE DATA SET  : 11.5000                            
+REMARK 200                                                                      
+REMARK 200 IN THE HIGHEST RESOLUTION SHELL.                                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE HIGH (A) : 0.90                     
+REMARK 200  HIGHEST RESOLUTION SHELL, RANGE LOW  (A) : 0.92                     
+REMARK 200  COMPLETENESS FOR SHELL     (%) : 77.7                               
+REMARK 200  DATA REDUNDANCY IN SHELL       : 2.70                               
+REMARK 200  R MERGE FOR SHELL          (I) : 0.19700                            
+REMARK 200  R SYM FOR SHELL            (I) : NULL                               
+REMARK 200  <I/SIGMA(I)> FOR SHELL         : NULL                               
+REMARK 200                                                                      
+REMARK 200 DIFFRACTION PROTOCOL: SINGLE WAVELENGTH                              
+REMARK 200 METHOD USED TO DETERMINE THE STRUCTURE: SAD                          
+REMARK 200 SOFTWARE USED: SHELXD                                                
+REMARK 200 STARTING MODEL: NULL                                                 
+REMARK 200                                                                      
+REMARK 200 REMARK: NULL                                                         
+REMARK 280                                                                      
+REMARK 280 CRYSTAL                                                              
+REMARK 280 SOLVENT CONTENT, VS   (%): 38.56                                     
+REMARK 280 MATTHEWS COEFFICIENT, VM (ANGSTROMS**3/DA): 2.00                     
+REMARK 280                                                                      
+REMARK 280 CRYSTALLIZATION CONDITIONS: NA THIOCYANATE, PEG 3350, GLYCEROL, PH   
+REMARK 280  7, VAPOR DIFFUSION, SITTING DROP, TEMPERATURE 298K                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY                                            
+REMARK 290 SYMMETRY OPERATORS FOR SPACE GROUP: P 1 21 1                         
+REMARK 290                                                                      
+REMARK 290      SYMOP   SYMMETRY                                                
+REMARK 290     NNNMMM   OPERATOR                                                
+REMARK 290       1555   X,Y,Z                                                   
+REMARK 290       2555   -X,Y+1/2,-Z                                             
+REMARK 290                                                                      
+REMARK 290     WHERE NNN -> OPERATOR NUMBER                                     
+REMARK 290           MMM -> TRANSLATION VECTOR                                  
+REMARK 290                                                                      
+REMARK 290 CRYSTALLOGRAPHIC SYMMETRY TRANSFORMATIONS                            
+REMARK 290 THE FOLLOWING TRANSFORMATIONS OPERATE ON THE ATOM/HETATM             
+REMARK 290 RECORDS IN THIS ENTRY TO PRODUCE CRYSTALLOGRAPHICALLY                
+REMARK 290 RELATED MOLECULES.                                                   
+REMARK 290   SMTRY1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 290   SMTRY3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 290   SMTRY1   2 -1.000000  0.000000  0.000000        0.00000            
+REMARK 290   SMTRY2   2  0.000000  1.000000  0.000000       19.20500            
+REMARK 290   SMTRY3   2  0.000000  0.000000 -1.000000        0.00000            
+REMARK 290                                                                      
+REMARK 290 REMARK: NULL                                                         
+REMARK 300                                                                      
+REMARK 300 BIOMOLECULE: 1                                                       
+REMARK 300 SEE REMARK 350 FOR THE AUTHOR PROVIDED AND/OR PROGRAM                
+REMARK 300 GENERATED ASSEMBLY INFORMATION FOR THE STRUCTURE IN                  
+REMARK 300 THIS ENTRY. THE REMARK MAY ALSO PROVIDE INFORMATION ON               
+REMARK 300 BURIED SURFACE AREA.                                                 
+REMARK 350                                                                      
+REMARK 350 COORDINATES FOR A COMPLETE MULTIMER REPRESENTING THE KNOWN           
+REMARK 350 BIOLOGICALLY SIGNIFICANT OLIGOMERIZATION STATE OF THE                
+REMARK 350 MOLECULE CAN BE GENERATED BY APPLYING BIOMT TRANSFORMATIONS          
+REMARK 350 GIVEN BELOW.  BOTH NON-CRYSTALLOGRAPHIC AND                          
+REMARK 350 CRYSTALLOGRAPHIC OPERATIONS ARE GIVEN.                               
+REMARK 350                                                                      
+REMARK 350 BIOMOLECULE: 1                                                       
+REMARK 350 AUTHOR DETERMINED BIOLOGICAL UNIT: MONOMERIC                         
+REMARK 350 SOFTWARE DETERMINED QUATERNARY STRUCTURE: MONOMERIC                  
+REMARK 350 SOFTWARE USED: PISA                                                  
+REMARK 350 APPLY THE FOLLOWING TO CHAINS: A                                     
+REMARK 350   BIOMT1   1  1.000000  0.000000  0.000000        0.00000            
+REMARK 350   BIOMT2   1  0.000000  1.000000  0.000000        0.00000            
+REMARK 350   BIOMT3   1  0.000000  0.000000  1.000000        0.00000            
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS IN SAME ASYMMETRIC UNIT                     
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS ARE IN CLOSE CONTACT.                            
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI           DISTANCE          
+REMARK 500   O    HOH A   297     O    HOH A   306              2.11            
+REMARK 500   O    HOH A   281     O    HOH A   299              2.13            
+REMARK 500   O    HOH A   295     O    HOH A   301              2.14            
+REMARK 500   O    HOH A   318     O    HOH A   319              2.15            
+REMARK 500   O    HOH A   311     O    HOH A   321              2.18            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: CLOSE CONTACTS                                             
+REMARK 500                                                                      
+REMARK 500 THE FOLLOWING ATOMS THAT ARE RELATED BY CRYSTALLOGRAPHIC             
+REMARK 500 SYMMETRY ARE IN CLOSE CONTACT.  AN ATOM LOCATED WITHIN 0.15          
+REMARK 500 ANGSTROMS OF A SYMMETRY RELATED ATOM IS ASSUMED TO BE ON A           
+REMARK 500 SPECIAL POSITION AND IS, THEREFORE, LISTED IN REMARK 375             
+REMARK 500 INSTEAD OF REMARK 500.  ATOMS WITH NON-BLANK ALTERNATE               
+REMARK 500 LOCATION INDICATORS ARE NOT INCLUDED IN THE CALCULATIONS.            
+REMARK 500                                                                      
+REMARK 500 DISTANCE CUTOFF:                                                     
+REMARK 500 2.2 ANGSTROMS FOR CONTACTS NOT INVOLVING HYDROGEN ATOMS              
+REMARK 500 1.6 ANGSTROMS FOR CONTACTS INVOLVING HYDROGEN ATOMS                  
+REMARK 500                                                                      
+REMARK 500  ATM1  RES C  SSEQI   ATM2  RES C  SSEQI  SSYMOP   DISTANCE          
+REMARK 500   HE2  HIS A    18    ZN     ZN A   101     2747     1.11            
+REMARK 500   O    HOH A   301     O    HOH A   325     2545     1.97            
+REMARK 500   O    HOH A   299     O    HOH A   302     2656     1.98            
+REMARK 500   NZ   LYS A    58     O    HOH A   253     2656     2.12            
+REMARK 500   O    HOH A   319     O    HOH A   333     2746     2.12            
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 500                                                                      
+REMARK 500 GEOMETRY AND STEREOCHEMISTRY                                         
+REMARK 500 SUBTOPIC: TORSION ANGLES                                             
+REMARK 500                                                                      
+REMARK 500 TORSION ANGLES OUTSIDE THE EXPECTED RAMACHANDRAN REGIONS:            
+REMARK 500 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 500 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE).                             
+REMARK 500                                                                      
+REMARK 500 STANDARD TABLE:                                                      
+REMARK 500 FORMAT:(10X,I3,1X,A3,1X,A1,I4,A1,4X,F7.2,3X,F7.2)                    
+REMARK 500                                                                      
+REMARK 500 EXPECTED VALUES: GJ KLEYWEGT AND TA JONES (1996). PHI/PSI-           
+REMARK 500 CHOLOGY: RAMACHANDRAN REVISITED. STRUCTURE 4, 1395 - 1400            
+REMARK 500                                                                      
+REMARK 500  M RES CSSEQI        PSI       PHI                                   
+REMARK 500    ASP A  37       97.83   -162.99                                   
+REMARK 500                                                                      
+REMARK 500 REMARK: NULL                                                         
+REMARK 620                                                                      
+REMARK 620 METAL COORDINATION                                                   
+REMARK 620 (M=MODEL NUMBER; RES=RESIDUE NAME; C=CHAIN IDENTIFIER;               
+REMARK 620 SSEQ=SEQUENCE NUMBER; I=INSERTION CODE):                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN A 102  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 PRO A  20   O                                                      
+REMARK 620 2 HOH A 330   O    96.9                                              
+REMARK 620 3 HOH A 221   O    84.3  90.5                                        
+REMARK 620 4 HOH A 264   O    87.9 173.3  85.2                                  
+REMARK 620 5 HOH A 332   O   135.3  48.3  71.3 125.1                            
+REMARK 620 N                    1     2     3     4                             
+REMARK 620                                                                      
+REMARK 620 COORDINATION ANGLES FOR:  M RES CSSEQI METAL                         
+REMARK 620                              ZN A 101  ZN                            
+REMARK 620 N RES CSSEQI ATOM                                                    
+REMARK 620 1 SCN A 103   N                                                      
+REMARK 620 2 LYS A  58   OXT 119.2                                              
+REMARK 620 N                    1                                               
+REMARK 800                                                                      
+REMARK 800 SITE                                                                 
+REMARK 800 SITE_IDENTIFIER: AC1                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN A 101                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC2                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE ZN A 102                  
+REMARK 800                                                                      
+REMARK 800 SITE_IDENTIFIER: AC3                                                 
+REMARK 800 EVIDENCE_CODE: SOFTWARE                                              
+REMARK 800 SITE_DESCRIPTION: BINDING SITE FOR RESIDUE SCN A 103                 
+REMARK 900                                                                      
+REMARK 900 RELATED ENTRIES                                                      
+REMARK 900 RELATED ID: 4NPE   RELATED DB: PDB                                   
+REMARK 900 RELATED ID: 4NPF   RELATED DB: PDB                                   
+DBREF  4NPD A    1    58  UNP    P38507   SPA_STAAU      270    327             
+SEQRES   1 A   58  ALA ASP ASN LYS PHE ASN LYS GLU GLN GLN ASN ALA PHE          
+SEQRES   2 A   58  TYR GLU ILE LEU HIS LEU PRO ASN LEU THR GLU GLU GLN          
+SEQRES   3 A   58  ARG ASN GLY PHE ILE GLN SER LEU LYS ASP ASP PRO SER          
+SEQRES   4 A   58  VAL SER LYS GLU ILE LEU ALA GLU ALA LYS LYS LEU ASN          
+SEQRES   5 A   58  ASP ALA GLN ALA PRO LYS                                      
+HET     ZN  A 101       1                                                       
+HET     ZN  A 102       1                                                       
+HET    SCN  A 103       3                                                       
+HETNAM      ZN ZINC ION                                                         
+HETNAM     SCN THIOCYANATE ION                                                  
+FORMUL   2   ZN    2(ZN 2+)                                                     
+FORMUL   4  SCN    C N S 1-                                                     
+FORMUL   5  HOH   *134(H2 O)                                                    
+HELIX    1   1 ASN A    6  LEU A   19  1                                  14    
+HELIX    2   2 THR A   23  ASP A   37  1                                  15    
+HELIX    3   3 VAL A   40  GLN A   55  1                                  16    
+LINK         O  APRO A  20                ZN    ZN A 102     1555   1555  1.91  
+LINK        ZN    ZN A 101                 N   SCN A 103     1555   1555  1.91  
+LINK         OXTBLYS A  58                ZN    ZN A 101     1555   1555  1.94  
+LINK        ZN    ZN A 102                 O  AHOH A 330     1555   1555  1.98  
+LINK         OXTALYS A  58                ZN    ZN A 101     1555   1555  2.03  
+LINK         O  BPRO A  20                ZN    ZN A 102     1555   1555  2.09  
+LINK        ZN    ZN A 102                 O   HOH A 221     1555   1555  2.15  
+LINK        ZN    ZN A 102                 O   HOH A 264     1555   1555  2.33  
+LINK        ZN    ZN A 102                 O   HOH A 332     1555   1555  2.65  
+SITE     1 AC1  3 GLU A  47  LYS A  58  SCN A 103                               
+SITE     1 AC2  6 PRO A  20  HOH A 221  HOH A 228  HOH A 264                    
+SITE     2 AC2  6 HOH A 330  HOH A 332                                          
+SITE     1 AC3  6 GLY A  29  PHE A  30  SER A  33  GLU A  47                    
+SITE     2 AC3  6 LYS A  58   ZN A 101                                          
+CRYST1   27.250   38.410   28.610  90.00 117.44  90.00 P 1 21 1      2          
+ORIGX1      1.000000  0.000000  0.000000        0.00000                         
+ORIGX2      0.000000  1.000000  0.000000        0.00000                         
+ORIGX3      0.000000  0.000000  1.000000        0.00000                         
+SCALE1      0.036697  0.000000  0.019055        0.00000                         
+SCALE2      0.000000  0.026035  0.000000        0.00000                         
+SCALE3      0.000000  0.000000  0.039384        0.00000                         
+ATOM      1  N  AALA A   1       0.666   9.647  -8.772  0.30 23.86           N  
+ANISOU    1  N  AALA A   1     3049   2995   3020     80    347     27       N  
+ATOM      2  N  BALA A   1       0.419   9.252  -8.647  0.70 24.12           N  
+ANISOU    2  N  BALA A   1     3069   3071   3025    -25    179     29       N  
+ATOM      3  CA AALA A   1       1.505  10.498  -7.937  0.30 23.67           C  
+ANISOU    3  CA AALA A   1     3025   2998   2970     67    237     73       C  
+ATOM      4  CA BALA A   1       1.446  10.092  -8.034  0.70 23.23           C  
+ANISOU    4  CA BALA A   1     2984   2965   2878    -35    167     88       C  
+ATOM      5  C  AALA A   1       1.868   9.672  -6.722  0.30 22.25           C  
+ANISOU    5  C  AALA A   1     2849   2867   2738     70     79    105       C  
+ATOM      6  C  BALA A   1       1.839   9.443  -6.724  0.70 21.39           C  
+ANISOU    6  C  BALA A   1     2770   2795   2561    -17     31    111       C  
+ATOM      7  O  AALA A   1       1.118   9.604  -5.739  0.30 22.68           O  
+ANISOU    7  O  AALA A   1     2893   2935   2791     61    202    153       O  
+ATOM      8  O  BALA A   1       1.184   9.623  -5.679  0.70 21.07           O  
+ANISOU    8  O  BALA A   1     2791   2814   2401    -64    141    151       O  
+ATOM      9  CB AALA A   1       0.777  11.755  -7.551  0.30 23.85           C  
+ANISOU    9  CB AALA A   1     3039   3004   3020     59    234     71       C  
+ATOM     10  CB BALA A   1       0.942  11.509  -7.813  0.70 23.49           C  
+ANISOU   10  CB BALA A   1     3004   2951   2971     -2    182     85       C  
+ATOM     11  H1 AALA A   1       0.557  10.027  -9.569  0.30 24.12           H  
+ATOM     12  H1 BALA A   1       0.198   9.585  -9.442  0.70 24.12           H  
+ATOM     13  H2 AALA A   1       1.055   8.853  -8.873  0.30 24.12           H  
+ATOM     14  H2 BALA A   1       0.733   8.426  -8.749  0.70 24.12           H  
+ATOM     15  H3 AALA A   1      -0.128   9.540  -8.384  0.30 24.12           H  
+ATOM     16  H3 BALA A   1      -0.300   9.233  -8.123  0.70 24.12           H  
+ATOM     17  HA AALA A   1       2.302  10.783  -8.410  0.30 23.23           H  
+ATOM     18  HA BALA A   1       2.215  10.163  -8.621  0.70 23.23           H  
+ATOM     19  HB1AALA A   1       1.352  12.305  -6.997  0.30 23.49           H  
+ATOM     20  HB1BALA A   1       1.643  12.042  -7.406  0.70 23.49           H  
+ATOM     21  HB2AALA A   1       0.533  12.246  -8.351  0.30 23.49           H  
+ATOM     22  HB2BALA A   1       0.692  11.900  -8.665  0.70 23.49           H  
+ATOM     23  HB3AALA A   1      -0.025  11.526  -7.056  0.30 23.49           H  
+ATOM     24  HB3BALA A   1       0.169  11.490  -7.227  0.70 23.49           H  
+ATOM     25  N  AASP A   2       3.118   9.189  -6.755  0.41 20.26           N  
+ANISOU   25  N  AASP A   2     2616   2658   2421     68   -130     47       N  
+ATOM     26  N  BASP A   2       3.115   8.981  -6.731  0.59 19.90           N  
+ANISOU   26  N  BASP A   2     2574   2668   2318    -25    -96    112       N  
+ATOM     27  CA AASP A   2       3.873   8.795  -5.565  0.41 18.08           C  
+ANISOU   27  CA AASP A   2     2389   2376   2105     74   -174     30       C  
+ATOM     28  CA BASP A   2       3.941   8.592  -5.546  0.59 17.08           C  
+ANISOU   28  CA BASP A   2     2225   2323   1941    -47    -82    148       C  
+ATOM     29  C  AASP A   2       4.127  10.049  -4.742  0.41 16.16           C  
+ANISOU   29  C  AASP A   2     2220   2083   1838     46     22    159       C  
+ATOM     30  C  BASP A   2       4.541   9.778  -4.763  0.59 14.29           C  
+ANISOU   30  C  BASP A   2     1846   2032   1551   -157    171    418       C  
+ATOM     31  O  AASP A   2       4.410  11.109  -5.302  0.41 16.49           O  
+ANISOU   31  O  AASP A   2     2320   2057   1889     31    152    243       O  
+ATOM     32  O  BASP A   2       5.335  10.574  -5.288  0.59 12.92           O  
+ANISOU   32  O  BASP A   2     1689   2170   1048   -244    262    376       O  
+ATOM     33  CB AASP A   2       5.215   8.176  -5.974  0.41 19.68           C  
+ANISOU   33  CB AASP A   2     2530   2517   2429     96    -70    -58       C  
+ATOM     34  CB BASP A   2       5.081   7.658  -6.017  0.59 18.55           C  
+ANISOU   34  CB BASP A   2     2394   2360   2293     12    132      8       C  
+ATOM     35  CG AASP A   2       6.138   9.172  -6.660  0.41 21.37           C  
+ANISOU   35  CG AASP A   2     2759   2676   2684    127     31    -50       C  
+ATOM     36  CG BASP A   2       6.160   7.411  -4.953  0.59 20.53           C  
+ANISOU   36  CG BASP A   2     2658   2576   2567    108    178    -70       C  
+ATOM     37  OD1AASP A   2       5.654   9.968  -7.498  0.41 21.85           O  
+ANISOU   37  OD1AASP A   2     2851   2728   2725    123     90    -77       O  
+ATOM     38  OD1BASP A   2       5.947   7.659  -3.749  0.59 20.92           O  
+ANISOU   38  OD1BASP A   2     2752   2618   2578    120    127    -83       O  
+ATOM     39  OD2AASP A   2       7.352   9.160  -6.359  0.41 22.20           O  
+ANISOU   39  OD2AASP A   2     2850   2748   2839    173     83    -52       O  
+ATOM     40  OD2BASP A   2       7.249   6.935  -5.340  0.59 21.48           O  
+ANISOU   40  OD2BASP A   2     2738   2633   2789    167    234    -99       O  
+ATOM     41  H  AASP A   2       3.556   9.081  -7.487  0.41 19.90           H  
+ATOM     42  H  BASP A   2       3.547   8.880  -7.468  0.59 19.90           H  
+ATOM     43  HA AASP A   2       3.373   8.140  -5.053  0.41 17.08           H  
+ATOM     44  HA BASP A   2       3.340   8.146  -4.929  0.59 17.08           H  
+ATOM     45  HB2AASP A   2       5.656   7.821  -5.186  0.41 18.55           H  
+ATOM     46  HB2BASP A   2       4.701   6.806  -6.283  0.59 18.55           H  
+ATOM     47  HB3AASP A   2       5.053   7.428  -6.570  0.41 18.55           H  
+ATOM     48  HB3BASP A   2       5.497   8.042  -6.805  0.59 18.55           H  
+ATOM     49  N  AASN A   3       4.018   9.944  -3.424  0.51 14.32           N  
+ANISOU   49  N  AASN A   3     1976   1888   1576     82   -118    219       N  
+ATOM     50  N  BASN A   3       4.186   9.850  -3.493  0.49 13.03           N  
+ANISOU   50  N  BASN A   3     1745   1799   1405    -80     26    608       N  
+ATOM     51  CA AASN A   3       4.221  11.092  -2.584  0.51 13.29           C  
+ANISOU   51  CA AASN A   3     1724   1639   1688    -92    -83    160       C  
+ATOM     52  CA BASN A   3       4.499  10.991  -2.705  0.49 12.79           C  
+ANISOU   52  CA BASN A   3     1672   1642   1545    -73     38    687       C  
+ATOM     53  C  AASN A   3       5.132  10.771  -1.453  0.51 12.12           C  
+ANISOU   53  C  AASN A   3     1516   1444   1646   -235   -148    135       C  
+ATOM     54  C  BASN A   3       5.432  10.657  -1.578  0.49  9.82           C  
+ANISOU   54  C  BASN A   3     1351   1265   1115   -119    -67    698       C  
+ATOM     55  O  AASN A   3       5.028  11.401  -0.414  0.51 13.23           O  
+ANISOU   55  O  AASN A   3     1682   1564   1781    -26    277    359       O  
+ATOM     56  O  BASN A   3       5.420  11.377  -0.584  0.49 11.14           O  
+ANISOU   56  O  BASN A   3     1667   1515   1051    174    426    615       O  
+ATOM     57  CB AASN A   3       2.897  11.626  -2.036  0.51 15.46           C  
+ANISOU   57  CB AASN A   3     2013   1960   1901     20   -199    245       C  
+ATOM     58  CB BASN A   3       3.204  11.606  -2.180  0.49 15.06           C  
+ANISOU   58  CB BASN A   3     1959   1930   1834     85    -65    712       C  
+ATOM     59  CG AASN A   3       2.084  12.322  -3.093  0.51 15.97           C  
+ANISOU   59  CG AASN A   3     2167   1944   1957    -17    -57    270       C  
+ATOM     60  CG BASN A   3       2.323  12.083  -3.302  0.49 16.27           C  
+ANISOU   60  CG BASN A   3     2216   2012   1954    127    118    613       C  
+ATOM     61  OD1AASN A   3       2.541  13.284  -3.713  0.51 15.84           O  
+ANISOU   61  OD1AASN A   3     2202   1823   1992    -36     26    285       O  
+ATOM     62  OD1BASN A   3       2.794  12.750  -4.219  0.49 16.39           O  
+ANISOU   62  OD1BASN A   3     2354   1966   1907    163    310    603       O  
+ATOM     63  ND2AASN A   3       0.880  11.830  -3.325  0.51 17.36           N  
+ANISOU   63  ND2AASN A   3     2300   2187   2111     61   -144    321       N  
+ATOM     64  ND2BASN A   3       1.057  11.705  -3.275  0.49 17.75           N  
+ANISOU   64  ND2BASN A   3     2334   2274   2137    170    -93    541       N  
+ATOM     65  H  AASN A   3       3.828   9.217  -3.006  0.51 13.03           H  
+ATOM     66  H  BASN A   3       3.757   9.232  -3.075  0.49 13.03           H  
+ATOM     67  HA AASN A   3       4.628  11.779  -3.135  0.51 12.79           H  
+ATOM     68  HA BASN A   3       4.961  11.635  -3.264  0.49 12.79           H  
+ATOM     69  HB2AASN A   3       2.382  10.892  -1.666  0.51 15.06           H  
+ATOM     70  HB2BASN A   3       2.726  10.950  -1.648  0.49 15.06           H  
+ATOM     71  HB3AASN A   3       3.075  12.243  -1.309  0.51 15.06           H  
+ATOM     72  HB3BASN A   3       3.413  12.349  -1.593  0.49 15.06           H  
+ATOM     73 HD21AASN A   3       0.381  12.183  -3.930  0.51 17.75           H  
+ATOM     74 HD21BASN A   3       0.528  11.926  -3.916  0.49 17.75           H  
+ATOM     75 HD22AASN A   3       0.596  11.157  -2.871  0.51 17.75           H  
+ATOM     76 HD22BASN A   3       0.762  11.238  -2.616  0.49 17.75           H  
+ATOM     77  N  ALYS A   4       6.054   9.832  -1.650  0.47 11.61           N  
+ANISOU   77  N  ALYS A   4     1496   1511   1404   -382   -172   -137       N  
+ATOM     78  N  BLYS A   4       6.270   9.619  -1.692  0.53  9.18           N  
+ANISOU   78  N  BLYS A   4     1265   1300    922   -387   -276    152       N  
+ATOM     79  CA ALYS A   4       7.100   9.691  -0.647  0.47  9.63           C  
+ANISOU   79  CA ALYS A   4     1283   1359   1018   -327    -42    -40       C  
+ATOM     80  CA BLYS A   4       7.232   9.382  -0.594  0.53  6.47           C  
+ANISOU   80  CA BLYS A   4      885    965    608   -257     92     38       C  
+ATOM     81  C  ALYS A   4       7.949  10.992  -0.651  0.47  8.27           C  
+ANISOU   81  C  ALYS A   4     1182   1377    581   -519     88     59       C  
+ATOM     82  C  BLYS A   4       8.266  10.497  -0.625  0.53  6.64           C  
+ANISOU   82  C  BLYS A   4      939   1004    579   -276    321     69       C  
+ATOM     83  O  ALYS A   4       8.236  11.572  -1.698  0.47  8.60           O  
+ANISOU   83  O  ALYS A   4     1137   1592    537   -535     50    110       O  
+ATOM     84  O  BLYS A   4       8.688  10.935  -1.684  0.53  8.23           O  
+ANISOU   84  O  BLYS A   4     1192   1236    701   -288    356     27       O  
+ATOM     85  CB ALYS A   4       7.851   8.348  -0.811  0.47  9.99           C  
+ANISOU   85  CB ALYS A   4     1305   1236   1256    -15    102    116       C  
+ATOM     86  CB BLYS A   4       7.846   7.977  -0.601  0.53  9.69           C  
+ANISOU   86  CB BLYS A   4     1142   1241   1298   -296    276    335       C  
+ATOM     87  CG ALYS A   4       6.980   7.121  -0.304  0.47  8.61           C  
+ANISOU   87  CG ALYS A   4     1058   1144   1070     36    260     34       C  
+ATOM     88  CG BLYS A   4       6.883   6.868  -0.222  0.53 10.01           C  
+ANISOU   88  CG BLYS A   4     1094   1358   1352   -319    144    281       C  
+ATOM     89  CD ALYS A   4       7.449   5.738  -0.782  0.47 12.27           C  
+ANISOU   89  CD ALYS A   4     1624   1715   1324    -64   -235     10       C  
+ATOM     90  CD BLYS A   4       7.599   5.562   0.020  0.53 12.87           C  
+ANISOU   90  CD BLYS A   4     1469   1704   1717   -258   -201    199       C  
+ATOM     91  CE ALYS A   4       6.563   4.621  -0.226  0.47 12.89           C  
+ANISOU   91  CE ALYS A   4     1664   1738   1497   -159     77   -136       C  
+ATOM     92  CE BLYS A   4       6.652   4.398  -0.050  0.53 12.65           C  
+ANISOU   92  CE BLYS A   4     1469   1688   1650   -245   -148    213       C  
+ATOM     93  NZ ALYS A   4       6.961   3.300  -0.770  0.47 10.99           N  
+ANISOU   93  NZ ALYS A   4     1491   1395   1290   -112    223   -176       N  
+ATOM     94  NZ BLYS A   4       7.360   3.104  -0.168  0.53 12.01           N  
+ANISOU   94  NZ BLYS A   4     1421   1491   1653    -58   -283    289       N  
+ATOM     95  H  ALYS A   4       6.093   9.294  -2.320  0.47  9.18           H  
+ATOM     96  H  BLYS A   4       6.304   9.068  -2.352  0.53  9.18           H  
+ATOM     97  HA ALYS A   4       6.746   9.616   0.253  0.47  6.47           H  
+ATOM     98  HA BLYS A   4       6.758   9.407   0.252  0.53  6.47           H  
+ATOM     99  HB2ALYS A   4       8.081   8.218  -1.744  0.47  9.69           H  
+ATOM    100  HB2BLYS A   4       8.199   7.795  -1.486  0.53  9.69           H  
+ATOM    101  HB3ALYS A   4       8.684   8.380  -0.315  0.47  9.69           H  
+ATOM    102  HB3BLYS A   4       8.597   7.961   0.013  0.53  9.69           H  
+ATOM    103  HG2ALYS A   4       6.975   7.127   0.666  0.47 10.01           H  
+ATOM    104  HG2BLYS A   4       6.395   7.122   0.577  0.53 10.01           H  
+ATOM    105  HG3ALYS A   4       6.064   7.253  -0.593  0.47 10.01           H  
+ATOM    106  HG3BLYS A   4       6.229   6.752  -0.929  0.53 10.01           H  
+ATOM    107  HD2ALYS A   4       7.438   5.709  -1.751  0.47 12.87           H  
+ATOM    108  HD2BLYS A   4       8.302   5.449  -0.639  0.53 12.87           H  
+ATOM    109  HD3ALYS A   4       8.367   5.593  -0.504  0.47 12.87           H  
+ATOM    110  HD3BLYS A   4       8.026   5.582   0.891  0.53 12.87           H  
+ATOM    111  HE2ALYS A   4       6.625   4.607   0.742  0.47 12.65           H  
+ATOM    112  HE2BLYS A   4       6.095   4.388   0.744  0.53 12.65           H  
+ATOM    113  HE3ALYS A   4       5.636   4.799  -0.448  0.47 12.65           H  
+ATOM    114  HE3BLYS A   4       6.060   4.511  -0.810  0.53 12.65           H  
+ATOM    115  HZ1ALYS A   4       6.432   2.668  -0.433  0.47 12.01           H  
+ATOM    116  HZ1BLYS A   4       6.766   2.443  -0.206  0.53 12.01           H  
+ATOM    117  HZ2ALYS A   4       6.884   3.308  -1.657  0.47 12.01           H  
+ATOM    118  HZ2BLYS A   4       7.854   3.102  -0.908  0.53 12.01           H  
+ATOM    119  HZ3ALYS A   4       7.806   3.129  -0.548  0.47 12.01           H  
+ATOM    120  HZ3BLYS A   4       7.887   2.988   0.540  0.53 12.01           H  
+ATOM    121  N  APHE A   5       8.256  11.503   0.535  0.45  7.44           N  
+ANISOU  121  N  APHE A   5     1038   1175    612   -465     60    111       N  
+ATOM    122  N  BPHE A   5       8.640  10.984   0.545  0.55  6.56           N  
+ANISOU  122  N  BPHE A   5      923    996    572   -229    281    159       N  
+ATOM    123  CA APHE A   5       9.022  12.738   0.679  0.45  7.32           C  
+ANISOU  123  CA APHE A   5     1003   1070    708   -551     54    176       C  
+ATOM    124  CA BPHE A   5       9.470  12.174   0.665  0.55  7.29           C  
+ANISOU  124  CA BPHE A   5     1072   1123    575   -354    171    217       C  
+ATOM    125  C  APHE A   5      10.411  12.601   0.061  0.45  8.01           C  
+ANISOU  125  C  APHE A   5     1120   1204    720   -565    157     41       C  
+ATOM    126  C  BPHE A   5      10.858  11.968   0.088  0.55  7.71           C  
+ANISOU  126  C  BPHE A   5     1140   1184    606   -314    257    153       C  
+ATOM    127  O  APHE A   5      11.037  11.538   0.118  0.45  8.96           O  
+ANISOU  127  O  APHE A   5     1286   1220    897   -545    126    162       O  
+ATOM    128  O  BPHE A   5      11.408  10.890   0.144  0.55  9.22           O  
+ANISOU  128  O  BPHE A   5     1245   1422    837   -332    386    119       O  
+ATOM    129  CB APHE A   5       9.210  13.102   2.159  0.45  8.36           C  
+ANISOU  129  CB APHE A   5     1159   1233    783   -531    -39    157       C  
+ATOM    130  CB BPHE A   5       9.657  12.524   2.143  0.55  6.61           C  
+ANISOU  130  CB BPHE A   5      870   1040    603   -321    242    127       C  
+ATOM    131  CG APHE A   5       7.973  13.604   2.852  0.45  8.33           C  
+ANISOU  131  CG APHE A   5     1148   1289    730   -479    -96    139       C  
+ATOM    132  CG BPHE A   5       8.457  13.149   2.830  0.55  6.79           C  
+ANISOU  132  CG BPHE A   5      900   1102    578   -391    163    107       C  
+ATOM    133  CD1APHE A   5       6.801  13.894   2.165  0.45 10.49           C  
+ANISOU  133  CD1APHE A   5     1374   1482   1128   -270    166    207       C  
+ATOM    134  CD1BPHE A   5       7.387  13.666   2.144  0.55  8.20           C  
+ANISOU  134  CD1BPHE A   5     1049   1200    867   -145    304    178       C  
+ATOM    135  CD2APHE A   5       7.993  13.769   4.206  0.45 11.17           C  
+ANISOU  135  CD2APHE A   5     1403   1576   1264   -261     44    -33       C  
+ATOM    136  CD2BPHE A   5       8.421  13.190   4.213  0.55  7.02           C  
+ANISOU  136  CD2BPHE A   5     1204    875    590   -227    159    -24       C  
+ATOM    137  CE1APHE A   5       5.699  14.368   2.828  0.45 10.45           C  
+ANISOU  137  CE1APHE A   5     1339   1353   1277   -255    261    113       C  
+ATOM    138  CE1BPHE A   5       6.318  14.252   2.827  0.55  9.61           C  
+ANISOU  138  CE1BPHE A   5     1157   1283   1212   -167    121    201       C  
+ATOM    139  CE2APHE A   5       6.903  14.230   4.863  0.45  9.94           C  
+ANISOU  139  CE2APHE A   5     1221   1323   1234   -269    224   -201       C  
+ATOM    140  CE2BPHE A   5       7.376  13.762   4.914  0.55  7.28           C  
+ANISOU  140  CE2BPHE A   5     1168    877    720   -184    194     -4       C  
+ATOM    141  CZ APHE A   5       5.761  14.562   4.180  0.45  9.93           C  
+ANISOU  141  CZ APHE A   5     1288   1288   1199   -268    385    -82       C  
+ATOM    142  CZ BPHE A   5       6.334  14.325   4.217  0.55  9.38           C  
+ANISOU  142  CZ BPHE A   5     1222   1305   1035   -282    -37     65       C  
+ATOM    143  H  APHE A   5       8.026  11.144   1.282  0.45  6.56           H  
+ATOM    144  H  BPHE A   5       8.419  10.633   1.299  0.55  6.56           H  
+ATOM    145  HA APHE A   5       8.519  13.430   0.223  0.45  7.29           H  
+ATOM    146  HA BPHE A   5       9.016  12.878   0.176  0.55  7.29           H  
+ATOM    147  HB2APHE A   5       9.534  12.320   2.632  0.45  6.61           H  
+ATOM    148  HB2BPHE A   5       9.898  11.715   2.622  0.55  6.61           H  
+ATOM    149  HB3APHE A   5       9.900  13.780   2.226  0.45  6.61           H  
+ATOM    150  HB3BPHE A   5      10.407  13.134   2.221  0.55  6.61           H  
+ATOM    151  HD1APHE A   5       6.764  13.765   1.245  0.45  8.20           H  
+ATOM    152  HD1BPHE A   5       7.373  13.626   1.215  0.55  8.20           H  
+ATOM    153  HD2APHE A   5       8.764  13.562   4.683  0.45  7.02           H  
+ATOM    154  HD2BPHE A   5       9.128  12.818   4.689  0.55  7.02           H  
+ATOM    155  HE1APHE A   5       4.916  14.556   2.362  0.45  9.61           H  
+ATOM    156  HE1BPHE A   5       5.595  14.594   2.352  0.55  9.61           H  
+ATOM    157  HE2APHE A   5       6.929  14.323   5.788  0.45  7.28           H  
+ATOM    158  HE2BPHE A   5       7.378  13.766   5.844  0.55  7.28           H  
+ATOM    159  HZ APHE A   5       5.032  14.918   4.635  0.45  9.38           H  
+ATOM    160  HZ BPHE A   5       5.644  14.752   4.671  0.55  9.38           H  
+ATOM    161  N  AASN A   6      10.914  13.682  -0.514  0.53  7.08           N  
+ANISOU  161  N  AASN A   6      985   1081    622   -440    280    -18       N  
+ATOM    162  N  BASN A   6      11.443  13.013  -0.457  0.47  7.06           N  
+ANISOU  162  N  BASN A   6     1065   1079    538   -305    298     52       N  
+ATOM    163  CA AASN A   6      12.331  13.719  -0.878  0.53  7.84           C  
+ANISOU  163  CA AASN A   6     1167   1134    678   -358    253    -82       C  
+ATOM    164  CA BASN A   6      12.887  13.013  -0.678  0.47  7.18           C  
+ANISOU  164  CA BASN A   6      935   1114    680   -266    378     93       C  
+ATOM    165  C  AASN A   6      13.193  14.013   0.355  0.53  6.29           C  
+ANISOU  165  C  AASN A   6      909    919    560   -200    368    -45       C  
+ATOM    166  C  BASN A   6      13.604  13.415   0.617  0.47  7.38           C  
+ANISOU  166  C  BASN A   6      991   1156    659   -245    379    122       C  
+ATOM    167  O  AASN A   6      12.666  14.146   1.461  0.53  5.82           O  
+ANISOU  167  O  AASN A   6      789    842    581    -18    390     64       O  
+ATOM    168  O  BASN A   6      12.969  13.627   1.649  0.47  7.02           O  
+ANISOU  168  O  BASN A   6      958   1189    522   -325    277    -22       O  
+ATOM    169  CB AASN A   6      12.593  14.710  -2.003  0.53  8.45           C  
+ANISOU  169  CB AASN A   6     1211   1247    753   -384    371    135       C  
+ATOM    170  CB BASN A   6      13.246  13.917  -1.858  0.47  7.71           C  
+ANISOU  170  CB BASN A   6     1080   1158    690   -268    428     35       C  
+ATOM    171  CG AASN A   6      12.282  16.153  -1.625  0.53  7.26           C  
+ANISOU  171  CG AASN A   6     1081   1150    528   -297    287     31       C  
+ATOM    172  CG BASN A   6      12.851  15.362  -1.642  0.47  7.99           C  
+ANISOU  172  CG BASN A   6     1169   1242    623   -188    364    220       C  
+ATOM    173  OD1AASN A   6      12.396  16.571  -0.488  0.53  7.55           O  
+ANISOU  173  OD1AASN A   6     1297   1030    540   -300    180     -5       O  
+ATOM    174  OD1BASN A   6      12.731  15.824  -0.538  0.47  8.75           O  
+ANISOU  174  OD1BASN A   6     1338   1404    583   -149    234     56       O  
+ATOM    175  ND2AASN A   6      11.932  16.930  -2.613  0.53  9.67           N  
+ANISOU  175  ND2AASN A   6     1485   1223    967    196    651     98       N  
+ATOM    176  ND2BASN A   6      12.707  16.084  -2.709  0.47  9.43           N  
+ANISOU  176  ND2BASN A   6     1360   1249    975    -73    644    106       N  
+ATOM    177  H  AASN A   6      10.468  14.393  -0.701  0.53  7.06           H  
+ATOM    178  H  BASN A   6      11.035  13.728  -0.706  0.47  7.06           H  
+ATOM    179  HA AASN A   6      12.581  12.844  -1.214  0.53  7.18           H  
+ATOM    180  HA BASN A   6      13.186  12.121  -0.912  0.47  7.18           H  
+ATOM    181  HB2AASN A   6      13.523  14.646  -2.271  0.53  7.71           H  
+ATOM    182  HB2BASN A   6      14.202  13.869  -2.016  0.47  7.71           H  
+ATOM    183  HB3AASN A   6      12.059  14.462  -2.774  0.53  7.71           H  
+ATOM    184  HB3BASN A   6      12.809  13.584  -2.658  0.47  7.71           H  
+ATOM    185 HD21AASN A   6      11.775  17.763  -2.470  0.53  9.43           H  
+ATOM    186 HD21BASN A   6      12.520  16.921  -2.640  0.47  9.43           H  
+ATOM    187 HD22AASN A   6      11.859  16.609  -3.407  0.53  9.43           H  
+ATOM    188 HD22BASN A   6      12.799  15.726  -3.486  0.47  9.43           H  
+ATOM    189  N  ALYS A   7      14.517  14.085   0.195  0.51  6.74           N  
+ANISOU  189  N  ALYS A   7      944    990    626    -21    384   -169       N  
+ATOM    190  N  BLYS A   7      14.923  13.496   0.585  0.49  7.69           N  
+ANISOU  190  N  BLYS A   7      988   1099    835   -162    415    254       N  
+ATOM    191  CA ALYS A   7      15.370  14.165   1.381  0.51  8.62           C  
+ANISOU  191  CA ALYS A   7     1023   1238   1013     84    414   -334       C  
+ATOM    192  CA BLYS A   7      15.652  13.784   1.806  0.49  9.33           C  
+ANISOU  192  CA BLYS A   7     1113   1375   1058   -145    292    279       C  
+ATOM    193  C  ALYS A   7      15.142  15.479   2.143  0.51  6.25           C  
+ANISOU  193  C  ALYS A   7      567   1104    702    -31    338    -72       C  
+ATOM    194  C  BLYS A   7      15.383  15.190   2.329  0.49  7.69           C  
+ANISOU  194  C  BLYS A   7      911   1198    814   -205    428    224       C  
+ATOM    195  O  ALYS A   7      15.073  15.473   3.369  0.51  6.24           O  
+ANISOU  195  O  ALYS A   7      734   1011    626     73    277      8       O  
+ATOM    196  O  BLYS A   7      15.289  15.403   3.527  0.49  7.97           O  
+ANISOU  196  O  BLYS A   7      978   1395    656   -326    218    194       O  
+ATOM    197  CB ALYS A   7      16.865  13.936   1.085  0.51 13.13           C  
+ANISOU  197  CB ALYS A   7     1534   1778   1676    178    393   -343       C  
+ATOM    198  CB BLYS A   7      17.150  13.564   1.607  0.49 13.63           C  
+ANISOU  198  CB BLYS A   7     1632   1843   1703    -33    254    193       C  
+ATOM    199  CG ALYS A   7      17.267  12.456   0.903  0.51 16.29           C  
+ANISOU  199  CG ALYS A   7     2024   2093   2074    171    440   -260       C  
+ATOM    200  CG BLYS A   7      17.905  13.252   2.879  0.49 17.06           C  
+ANISOU  200  CG BLYS A   7     2116   2216   2150     30    241     27       C  
+ATOM    201  CD ALYS A   7      18.758  12.208   1.186  0.51 18.49           C  
+ANISOU  201  CD ALYS A   7     2335   2352   2338     79    463   -169       C  
+ATOM    202  CD BLYS A   7      17.242  12.105   3.634  0.49 19.17           C  
+ANISOU  202  CD BLYS A   7     2416   2433   2437     62    310     50       C  
+ATOM    203  CE ALYS A   7      19.034  11.823   2.625  0.51 20.93           C  
+ANISOU  203  CE ALYS A   7     2662   2674   2615     31    403   -104       C  
+ATOM    204  CE BLYS A   7      18.192  10.993   3.987  0.49 22.81           C  
+ANISOU  204  CE BLYS A   7     2863   2938   2868     40    247      9       C  
+ATOM    205  NZ ALYS A   7      19.198  10.344   2.781  0.51 22.04           N  
+ANISOU  205  NZ ALYS A   7     2807   2833   2736     -3    347   -116       N  
+ATOM    206  NZ BLYS A   7      17.406   9.748   4.242  0.49 22.44           N  
+ANISOU  206  NZ BLYS A   7     2849   2832   2846     20    394    -24       N  
+ATOM    207  H  ALYS A   7      14.927  14.089  -0.561  0.51  7.69           H  
+ATOM    208  H  BLYS A   7      15.407  13.390  -0.118  0.49  7.69           H  
+ATOM    209  HA ALYS A   7      15.101  13.429   1.953  0.51  9.33           H  
+ATOM    210  HA BLYS A   7      15.329  13.164   2.478  0.49  9.33           H  
+ATOM    211  HB2ALYS A   7      17.101  14.424   0.281  0.51 13.63           H  
+ATOM    212  HB2BLYS A   7      17.279  12.836   0.979  0.49 13.63           H  
+ATOM    213  HB3ALYS A   7      17.387  14.314   1.810  0.51 13.63           H  
+ATOM    214  HB3BLYS A   7      17.532  14.358   1.202  0.49 13.63           H  
+ATOM    215  HG2ALYS A   7      16.733  11.904   1.496  0.51 17.06           H  
+ATOM    216  HG2BLYS A   7      18.822  13.018   2.667  0.49 17.06           H  
+ATOM    217  HG3ALYS A   7      17.063  12.178  -0.004  0.51 17.06           H  
+ATOM    218  HG3BLYS A   7      17.937  14.041   3.443  0.49 17.06           H  
+ATOM    219  HD2ALYS A   7      19.080  11.504   0.601  0.51 19.17           H  
+ATOM    220  HD2BLYS A   7      16.843  12.450   4.448  0.49 19.17           H  
+ATOM    221  HD3ALYS A   7      19.260  13.009   0.969  0.51 19.17           H  
+ATOM    222  HD3BLYS A   7      16.521  11.746   3.094  0.49 19.17           H  
+ATOM    223  HE2ALYS A   7      19.837  12.272   2.932  0.51 22.81           H  
+ATOM    224  HE2BLYS A   7      18.823  10.849   3.265  0.49 22.81           H  
+ATOM    225  HE3ALYS A   7      18.305  12.129   3.187  0.51 22.81           H  
+ATOM    226  HE3BLYS A   7      18.709  11.230   4.773  0.49 22.81           H  
+ATOM    227  HZ1ALYS A   7      19.358  10.151   3.635  0.51 22.44           H  
+ATOM    228  HZ1BLYS A   7      17.963   9.062   4.352  0.49 22.44           H  
+ATOM    229  HZ2ALYS A   7      18.453   9.933   2.519  0.51 22.44           H  
+ATOM    230  HZ2BLYS A   7      16.915   9.852   4.977  0.49 22.44           H  
+ATOM    231  HZ3ALYS A   7      19.880  10.066   2.281  0.51 22.44           H  
+ATOM    232  HZ3BLYS A   7      16.871   9.587   3.549  0.49 22.44           H  
+ATOM    233  N  AGLU A   8      15.011  16.617   1.467  0.47  5.63           N  
+ANISOU  233  N  AGLU A   8      672    915    551   -100    333    119       N  
+ATOM    234  N  BGLU A   8      15.274  16.156   1.432  0.53  8.84           N  
+ANISOU  234  N  BGLU A   8     1157   1369    833   -422    346     95       N  
+ATOM    235  CA AGLU A   8      14.834  17.879   2.210  0.47  6.08           C  
+ANISOU  235  CA AGLU A   8      756    834    720   -143    343    184       C  
+ATOM    236  CA BGLU A   8      14.970  17.542   1.800  0.53  8.81           C  
+ANISOU  236  CA BGLU A   8     1217   1308    824   -477    225    167       C  
+ATOM    237  C  AGLU A   8      13.493  17.887   2.949  0.47  5.72           C  
+ANISOU  237  C  AGLU A   8      835    687    650   -204    172    219       C  
+ATOM    238  C  BGLU A   8      13.696  17.574   2.656  0.53  7.23           C  
+ANISOU  238  C  BGLU A   8     1065   1026    656   -331    233    138       C  
+ATOM    239  O  AGLU A   8      13.379  18.446   4.037  0.47  5.02           O  
+ANISOU  239  O  AGLU A   8      760    569    580     11    225     16       O  
+ATOM    240  O  BGLU A   8      13.657  18.138   3.754  0.53  7.88           O  
+ANISOU  240  O  BGLU A   8     1070   1075    850   -277    205     97       O  
+ATOM    241  CB AGLU A   8      14.995  19.132   1.329  0.47  7.87           C  
+ANISOU  241  CB AGLU A   8      983   1103    904   -124    279    176       C  
+ATOM    242  CB BGLU A   8      14.815  18.407   0.533  0.53  8.54           C  
+ANISOU  242  CB BGLU A   8     1199   1372    674   -428    211    140       C  
+ATOM    243  CG AGLU A   8      13.888  19.405   0.321  0.47  6.60           C  
+ANISOU  243  CG AGLU A   8      826    877    804   -273    276    175       C  
+ATOM    244  CG BGLU A   8      14.384  19.887   0.709  0.53  8.82           C  
+ANISOU  244  CG BGLU A   8     1245   1294    814   -180    453    278       C  
+ATOM    245  CD AGLU A   8      14.151  20.644  -0.534  0.47  8.29           C  
+ANISOU  245  CD AGLU A   8     1153   1113    886    -36    428    310       C  
+ATOM    246  CD BGLU A   8      14.189  20.546  -0.637  0.53  9.45           C  
+ANISOU  246  CD BGLU A   8     1255   1386    950   -122    584    219       C  
+ATOM    247  OE1AGLU A   8      15.336  20.900  -0.902  0.47  7.70           O  
+ANISOU  247  OE1AGLU A   8     1336   1030    561    146     61    153       O  
+ATOM    248  OE1BGLU A   8      13.084  20.504  -1.241  0.53 10.68           O  
+ANISOU  248  OE1BGLU A   8     1528   1449   1080    -41    440     30       O  
+ATOM    249  OE2AGLU A   8      13.173  21.360  -0.845  0.47  8.88           O  
+ANISOU  249  OE2AGLU A   8     1376   1143    855    134    481    332       O  
+ATOM    250  OE2BGLU A   8      15.198  21.100  -1.103  0.53  8.53           O  
+ANISOU  250  OE2BGLU A   8     1294   1350    596    -64    399    200       O  
+ATOM    251  H  AGLU A   8      15.020  16.689   0.610  0.47  8.84           H  
+ATOM    252  H  BGLU A   8      15.374  16.032   0.587  0.53  8.84           H  
+ATOM    253  HA AGLU A   8      15.551  17.919   2.863  0.47  8.81           H  
+ATOM    254  HA BGLU A   8      15.701  17.910   2.321  0.53  8.81           H  
+ATOM    255  HB2AGLU A   8      15.071  19.904   1.911  0.47  8.54           H  
+ATOM    256  HB2BGLU A   8      15.663  18.399   0.062  0.53  8.54           H  
+ATOM    257  HB3AGLU A   8      15.833  19.057   0.846  0.47  8.54           H  
+ATOM    258  HB3BGLU A   8      14.166  17.975  -0.044  0.53  8.54           H  
+ATOM    259  HG2AGLU A   8      13.788  18.634  -0.259  0.47  8.82           H  
+ATOM    260  HG2BGLU A   8      13.560  19.931   1.219  0.53  8.82           H  
+ATOM    261  HG3AGLU A   8      13.048  19.516   0.793  0.47  8.82           H  
+ATOM    262  HG3BGLU A   8      15.057  20.367   1.216  0.53  8.82           H  
+ATOM    263  N  AGLN A   9      12.488  17.278   2.346  0.55  5.24           N  
+ANISOU  263  N  AGLN A   9      886    674    430   -157    219    131       N  
+ATOM    264  N  BGLN A   9      12.643  16.962   2.134  0.45  7.06           N  
+ANISOU  264  N  BGLN A   9      993   1035    653   -274    150    203       N  
+ATOM    265  CA AGLN A   9      11.182  17.227   2.979  0.55  5.38           C  
+ANISOU  265  CA AGLN A   9      872    745    427    -13     84     43       C  
+ATOM    266  CA BGLN A   9      11.351  16.969   2.799  0.45  6.41           C  
+ANISOU  266  CA BGLN A   9      939    916    579   -176    280    254       C  
+ATOM    267  C  AGLN A   9      11.199  16.272   4.188  0.55  4.26           C  
+ANISOU  267  C  AGLN A   9      655    561    401    -43    130     -8       C  
+ATOM    268  C  BGLN A   9      11.429  16.176   4.113  0.45  5.42           C  
+ANISOU  268  C  BGLN A   9      804    804    451   -245    208    109       C  
+ATOM    269  O  AGLN A   9      10.630  16.591   5.229  0.55  4.66           O  
+ANISOU  269  O  AGLN A   9      627    581    563     -7    228     55       O  
+ATOM    270  O  BGLN A   9      10.923  16.618   5.149  0.45  5.40           O  
+ANISOU  270  O  BGLN A   9      925    777    351   -161     90     83       O  
+ATOM    271  CB AGLN A   9      10.144  16.797   1.967  0.55  5.69           C  
+ANISOU  271  CB AGLN A   9      875    776    511    -19    182     60       C  
+ATOM    272  CB BGLN A   9      10.271  16.362   1.885  0.45  6.67           C  
+ANISOU  272  CB BGLN A   9      907   1024    603   -151    277    289       C  
+ATOM    273  CG AGLN A   9       9.927  17.842   0.909  0.55  6.68           C  
+ANISOU  273  CG AGLN A   9      908    978    653    -13     35    178       C  
+ATOM    274  CG BGLN A   9       9.908  17.256   0.668  0.45  8.52           C  
+ANISOU  274  CG BGLN A   9     1178   1261    796   -272    207    441       C  
+ATOM    275  CD AGLN A   9       9.255  17.310  -0.297  0.55  6.75           C  
+ANISOU  275  CD AGLN A   9      927   1212    425     52      8    112       C  
+ATOM    276  CD BGLN A   9       9.169  16.522  -0.429  0.45 10.06           C  
+ANISOU  276  CD BGLN A   9     1416   1520    884   -458     89    435       C  
+ATOM    277  OE1AGLN A   9       8.993  16.110  -0.423  0.55  8.04           O  
+ANISOU  277  OE1AGLN A   9     1145   1381    528    -78   -147    -61       O  
+ATOM    278  OE1BGLN A   9       9.329  15.305  -0.606  0.45 10.76           O  
+ANISOU  278  OE1BGLN A   9     1509   1761    819   -444   -108    481       O  
+ATOM    279  NE2AGLN A   9       9.002  18.205  -1.221  0.55  8.48           N  
+ANISOU  279  NE2AGLN A   9     1177   1394    651    161    -47    177       N  
+ATOM    280  NE2BGLN A   9       8.353  17.258  -1.185  0.45 12.71           N  
+ANISOU  280  NE2BGLN A   9     1664   1731   1436   -333   -132    248       N  
+ATOM    281  H  AGLN A   9      12.538  16.892   1.579  0.55  7.06           H  
+ATOM    282  H  BGLN A   9      12.657  16.533   1.389  0.45  7.06           H  
+ATOM    283  HA AGLN A   9      10.954  18.112   3.305  0.55  6.41           H  
+ATOM    284  HA BGLN A   9      11.112  17.888   2.996  0.45  6.41           H  
+ATOM    285  HB2AGLN A   9      10.424  15.968   1.549  0.55  6.67           H  
+ATOM    286  HB2BGLN A   9      10.578  15.500   1.563  0.45  6.67           H  
+ATOM    287  HB3AGLN A   9       9.306  16.617   2.420  0.55  6.67           H  
+ATOM    288  HB3BGLN A   9       9.470  16.200   2.408  0.45  6.67           H  
+ATOM    289  HG2AGLN A   9       9.395  18.564   1.278  0.55  8.52           H  
+ATOM    290  HG2BGLN A   9       9.363  17.998   0.973  0.45  8.52           H  
+ATOM    291  HG3AGLN A   9      10.783  18.222   0.656  0.55  8.52           H  
+ATOM    292  HG3BGLN A   9      10.722  17.634   0.301  0.45  8.52           H  
+ATOM    293 HE21AGLN A   9       9.203  19.030  -1.087  0.55 12.71           H  
+ATOM    294 HE21BGLN A   9       8.268  18.100  -1.032  0.45 12.71           H  
+ATOM    295 HE22AGLN A   9       8.635  17.967  -1.961  0.55 12.71           H  
+ATOM    296 HE22BGLN A   9       7.912  16.891  -1.825  0.45 12.71           H  
+ATOM    297  N  AGLN A  10      11.827  15.104   4.031  0.59  4.30           N  
+ANISOU  297  N  AGLN A  10      665    655    315    -39    165    -22       N  
+ATOM    298  N  BGLN A  10      12.062  15.010   4.063  0.41  5.60           N  
+ANISOU  298  N  BGLN A  10      863    731    533   -174    267     35       N  
+ATOM    299  CA AGLN A  10      11.973  14.186   5.163  0.59  4.13           C  
+ANISOU  299  CA AGLN A  10      683    520    367    -81    256    -16       C  
+ATOM    300  CA BGLN A  10      12.107  14.137   5.228  0.41  5.87           C  
+ANISOU  300  CA BGLN A  10      903    712    616   -109     85     94       C  
+ATOM    301  C  AGLN A  10      12.754  14.848   6.300  0.59  4.29           C  
+ANISOU  301  C  AGLN A  10      690    522    417     18    268     67       C  
+ATOM    302  C  BGLN A  10      12.855  14.802   6.367  0.41  5.60           C  
+ANISOU  302  C  BGLN A  10      980    656    493     -8     57     11       C  
+ATOM    303  O  AGLN A  10      12.386  14.729   7.461  0.59  4.40           O  
+ANISOU  303  O  AGLN A  10      744    495    433      3    310     54       O  
+ATOM    304  O  BGLN A  10      12.416  14.777   7.521  0.41  5.22           O  
+ANISOU  304  O  BGLN A  10      973    584    426    -13     -6    -26       O  
+ATOM    305  CB AGLN A  10      12.669  12.896   4.733  0.59  4.33           C  
+ANISOU  305  CB AGLN A  10      635    604    408     17    261   -122       C  
+ATOM    306  CB BGLN A  10      12.776  12.814   4.879  0.41  8.29           C  
+ANISOU  306  CB BGLN A  10     1108   1046    996    -90    -81   -166       C  
+ATOM    307  CG AGLN A  10      12.832  11.916   5.905  0.59  6.19           C  
+ANISOU  307  CG AGLN A  10      975    689    689      3    353    -56       C  
+ATOM    308  CG BGLN A  10      12.719  11.833   6.025  0.41  8.77           C  
+ANISOU  308  CG BGLN A  10     1211   1074   1047     33   -124   -142       C  
+ATOM    309  CD AGLN A  10      13.417  10.612   5.438  0.59  6.92           C  
+ANISOU  309  CD AGLN A  10      850    730   1050    -12    194   -173       C  
+ATOM    310  CD BGLN A  10      13.286  10.479   5.668  0.41  9.76           C  
+ANISOU  310  CD BGLN A  10     1241   1124   1341     60   -275   -209       C  
+ATOM    311  OE1AGLN A  10      12.771   9.842   4.723  0.59  5.63           O  
+ANISOU  311  OE1AGLN A  10      619    571    949   -117    418   -141       O  
+ATOM    312  OE1BGLN A  10      13.093   9.977   4.545  0.41  9.85           O  
+ANISOU  312  OE1BGLN A  10     1181    983   1578    -29   -310   -346       O  
+ATOM    313  NE2AGLN A  10      14.664  10.366   5.804  0.59 10.34           N  
+ANISOU  313  NE2AGLN A  10     1216   1217   1497    177   -114   -289       N  
+ATOM    314  NE2BGLN A  10      13.999   9.877   6.618  0.41 12.16           N  
+ANISOU  314  NE2BGLN A  10     1565   1508   1547     79   -446   -274       N  
+ATOM    315  H  AGLN A  10      12.170  14.828   3.292  0.59  5.60           H  
+ATOM    316  H  BGLN A  10      12.469  14.707   3.369  0.41  5.60           H  
+ATOM    317  HA AGLN A  10      11.084  13.965   5.482  0.59  5.87           H  
+ATOM    318  HA BGLN A  10      11.195  13.966   5.509  0.41  5.87           H  
+ATOM    319  HB2AGLN A  10      12.157  12.473   4.026  0.59  8.29           H  
+ATOM    320  HB2BGLN A  10      12.342  12.428   4.102  0.41  8.29           H  
+ATOM    321  HB3AGLN A  10      13.541  13.107   4.364  0.59  8.29           H  
+ATOM    322  HB3BGLN A  10      13.702  12.974   4.637  0.41  8.29           H  
+ATOM    323  HG2AGLN A  10      13.406  12.308   6.582  0.59  8.77           H  
+ATOM    324  HG2BGLN A  10      13.209  12.195   6.780  0.41  8.77           H  
+ATOM    325  HG3AGLN A  10      11.970  11.757   6.321  0.59  8.77           H  
+ATOM    326  HG3BGLN A  10      11.798  11.728   6.309  0.41  8.77           H  
+ATOM    327 HE21AGLN A  10      15.084  10.926   6.304  0.59 12.16           H  
+ATOM    328 HE21BGLN A  10      14.108  10.259   7.381  0.41 12.16           H  
+ATOM    329 HE22AGLN A  10      15.055   9.646   5.542  0.59 12.16           H  
+ATOM    330 HE22BGLN A  10      14.350   9.106   6.469  0.41 12.16           H  
+ATOM    331  N  AASN A  11      13.844  15.539   5.961  0.46  4.14           N  
+ANISOU  331  N  AASN A  11      605    645    324    -24    196     82       N  
+ATOM    332  N  BASN A  11      13.998  15.393   6.045  0.54  6.21           N  
+ANISOU  332  N  BASN A  11      918    786    654    -90    131    -13       N  
+ATOM    333  CA AASN A  11      14.654  16.205   6.979  0.46  4.97           C  
+ANISOU  333  CA AASN A  11      648    763    477   -173    126     68       C  
+ATOM    334  CA BASN A  11      14.797  16.004   7.083  0.54  6.79           C  
+ANISOU  334  CA BASN A  11      981    851    748    -80     46    -48       C  
+ATOM    335  C  AASN A  11      13.806  17.233   7.729  0.46  4.77           C  
+ANISOU  335  C  AASN A  11      691    739    383   -245     22     48       C  
+ATOM    336  C  BASN A  11      13.995  17.093   7.795  0.54  5.96           C  
+ANISOU  336  C  BASN A  11      965    671    626   -126    115    -36       C  
+ATOM    337  O  AASN A  11      13.820  17.283   8.972  0.46  4.96           O  
+ANISOU  337  O  AASN A  11      724    795    364   -176     55     62       O  
+ATOM    338  O  BASN A  11      14.056  17.200   9.020  0.54  6.38           O  
+ANISOU  338  O  BASN A  11     1015    752    659    -46    -60   -159       O  
+ATOM    339  CB AASN A  11      15.853  16.926   6.334  0.46  6.38           C  
+ANISOU  339  CB AASN A  11      685    964    774   -128     45     51       C  
+ATOM    340  CB BASN A  11      16.077  16.573   6.482  0.54  6.97           C  
+ANISOU  340  CB BASN A  11      820    942    887    -40     71   -163       C  
+ATOM    341  CG AASN A  11      16.942  15.971   5.822  0.46  8.91           C  
+ANISOU  341  CG AASN A  11      860   1279   1246    155    181     93       C  
+ATOM    342  CG BASN A  11      17.088  15.505   6.105  0.54  9.31           C  
+ANISOU  342  CG BASN A  11     1053   1142   1340     13    207     39       C  
+ATOM    343  OD1AASN A  11      16.998  14.807   6.193  0.46 10.25           O  
+ANISOU  343  OD1AASN A  11     1076   1377   1440    367    313    206       O  
+ATOM    344  OD1BASN A  11      17.036  14.371   6.593  0.54 11.77           O  
+ANISOU  344  OD1BASN A  11     1418   1286   1767    148    366    188       O  
+ATOM    345  ND2AASN A  11      17.812  16.487   4.971  0.46 10.52           N  
+ANISOU  345  ND2AASN A  11     1219   1444   1334    186    178    132       N  
+ATOM    346  ND2BASN A  11      18.018  15.870   5.244  0.54 10.40           N  
+ANISOU  346  ND2BASN A  11     1195   1334   1421     48    212    -42       N  
+ATOM    347  H  AASN A  11      14.128  15.633   5.155  0.46  6.21           H  
+ATOM    348  H  BASN A  11      14.319  15.449   5.249  0.54  6.21           H  
+ATOM    349  HA AASN A  11      14.980  15.530   7.595  0.46  6.79           H  
+ATOM    350  HA BASN A  11      15.038  15.331   7.739  0.54  6.79           H  
+ATOM    351  HB2AASN A  11      15.535  17.468   5.595  0.46  6.97           H  
+ATOM    352  HB2BASN A  11      15.854  17.092   5.693  0.54  6.97           H  
+ATOM    353  HB3AASN A  11      16.244  17.532   6.983  0.46  6.97           H  
+ATOM    354  HB3BASN A  11      16.482  17.183   7.118  0.54  6.97           H  
+ATOM    355 HD21AASN A  11      18.447  16.000   4.657  0.46 10.40           H  
+ATOM    356 HD21BASN A  11      18.622  15.309   5.000  0.54 10.40           H  
+ATOM    357 HD22AASN A  11      17.743  17.310   4.731  0.46 10.40           H  
+ATOM    358 HD22BASN A  11      18.020  16.669   4.927  0.54 10.40           H  
+ATOM    359  N  AALA A  12      13.083  18.074   6.988  0.43  4.66           N  
+ANISOU  359  N  AALA A  12      792    590    387   -169    120    175       N  
+ATOM    360  N  BALA A  12      13.219  17.888   7.061  0.57  6.02           N  
+ANISOU  360  N  BALA A  12     1053    670    562   -185      9   -156       N  
+ATOM    361  CA AALA A  12      12.243  19.109   7.600  0.43  5.81           C  
+ANISOU  361  CA AALA A  12     1021    598    587   -304     95    179       C  
+ATOM    362  CA BALA A  12      12.370  18.924   7.682  0.57  5.00           C  
+ANISOU  362  CA BALA A  12      945    479    477    -23    -32    -90       C  
+ATOM    363  C  AALA A  12      11.305  18.419   8.559  0.43  4.90           C  
+ANISOU  363  C  AALA A  12      928    388    546   -131    -39     83       C  
+ATOM    364  C  BALA A  12      11.183  18.358   8.531  0.57  4.53           C  
+ANISOU  364  C  BALA A  12      900    392    431     92     -5     -9       C  
+ATOM    365  O  AALA A  12      11.134  18.826   9.696  0.43  4.38           O  
+ANISOU  365  O  AALA A  12      891    368    405   -108   -123      9       O  
+ATOM    366  O  BALA A  12      10.889  18.872   9.609  0.57  4.79           O  
+ANISOU  366  O  BALA A  12      921    473    426    120     82    -80       O  
+ATOM    367  CB AALA A  12      11.438  19.880   6.548  0.43  7.48           C  
+ANISOU  367  CB AALA A  12     1149    913    781   -180    -55    394       C  
+ATOM    368  CB BALA A  12      11.832  19.865   6.611  0.57  5.35           C  
+ANISOU  368  CB BALA A  12      899    575    561   -179    -68     10       C  
+ATOM    369  H  AALA A  12      13.064  18.063   6.128  0.43  6.02           H  
+ATOM    370  H  BALA A  12      13.165  17.850   6.204  0.57  6.02           H  
+ATOM    371  HA AALA A  12      12.804  19.754   8.057  0.43  5.00           H  
+ATOM    372  HA BALA A  12      12.943  19.400   8.303  0.57  5.00           H  
+ATOM    373  HB1AALA A  12      10.895  20.554   6.986  0.43  5.35           H  
+ATOM    374  HB1BALA A  12      11.275  20.543   7.025  0.57  5.35           H  
+ATOM    375  HB2AALA A  12      12.046  20.309   5.925  0.43  5.35           H  
+ATOM    376  HB2BALA A  12      12.573  20.292   6.153  0.57  5.35           H  
+ATOM    377  HB3AALA A  12      10.863  19.265   6.066  0.43  5.35           H  
+ATOM    378  HB3BALA A  12      11.305  19.361   5.972  0.57  5.35           H  
+ATOM    379  N  APHE A  13      10.707  17.346   8.070  0.49  4.65           N  
+ANISOU  379  N  APHE A  13      753    502    512    -64     19     95       N  
+ATOM    380  N  BPHE A  13      10.481  17.351   8.026  0.51  3.45           N  
+ANISOU  380  N  BPHE A  13      578    446    286     37     23   -103       N  
+ATOM    381  CA APHE A  13       9.597  16.721   8.766  0.49  4.35           C  
+ANISOU  381  CA APHE A  13      695    471    486    111     76    -97       C  
+ATOM    382  CA BPHE A  13       9.428  16.702   8.792  0.51  3.84           C  
+ANISOU  382  CA BPHE A  13      539    536    385     81     13   -103       C  
+ATOM    383  C  APHE A  13      10.015  16.184  10.113  0.49  4.32           C  
+ANISOU  383  C  APHE A  13      673    426    541      1     95    -42       C  
+ATOM    384  C  BPHE A  13      10.013  16.151  10.117  0.51  3.37           C  
+ANISOU  384  C  BPHE A  13      578    352    352    -56     80    -70       C  
+ATOM    385  O  APHE A  13       9.350  16.428  11.126  0.49  4.32           O  
+ANISOU  385  O  APHE A  13      646    483    512     36     50    -64       O  
+ATOM    386  O  BPHE A  13       9.490  16.433  11.199  0.51  3.35           O  
+ANISOU  386  O  BPHE A  13      529    461    282    -16     88    -53       O  
+ATOM    387  CB APHE A  13       9.047  15.573   7.926  0.49  5.66           C  
+ANISOU  387  CB APHE A  13      722    744    686    116    125    -88       C  
+ATOM    388  CB BPHE A  13       8.791  15.617   7.901  0.51  2.99           C  
+ANISOU  388  CB BPHE A  13      394    485    258     68     26   -101       C  
+ATOM    389  CG APHE A  13       7.761  14.992   8.452  0.49  5.05           C  
+ANISOU  389  CG APHE A  13      572    846    500     18    131   -300       C  
+ATOM    390  CG BPHE A  13       7.439  15.142   8.354  0.51  4.55           C  
+ANISOU  390  CG BPHE A  13      621    642    467     21     92   -232       C  
+ATOM    391  CD1APHE A  13       7.751  13.982   9.375  0.49  5.89           C  
+ANISOU  391  CD1APHE A  13      704    889    647   -283    -30   -107       C  
+ATOM    392  CD1BPHE A  13       7.292  14.149   9.294  0.51  5.08           C  
+ANISOU  392  CD1BPHE A  13      765    560    605    151     94    -69       C  
+ATOM    393  CD2APHE A  13       6.547  15.478   7.949  0.49  8.01           C  
+ANISOU  393  CD2APHE A  13      935   1065   1044     97    -80   -220       C  
+ATOM    394  CD2BPHE A  13       6.295  15.662   7.747  0.51  5.53           C  
+ANISOU  394  CD2BPHE A  13      552    823    726     74     25   -153       C  
+ATOM    395  CE1APHE A  13       6.544  13.468   9.800  0.49  8.31           C  
+ANISOU  395  CE1APHE A  13     1084   1221    852   -173    -13   -190       C  
+ATOM    396  CE1BPHE A  13       6.030  13.709   9.636  0.51  5.95           C  
+ANISOU  396  CE1BPHE A  13      831    807    624    106    310   -242       C  
+ATOM    397  CE2APHE A  13       5.338  14.968   8.337  0.49  7.84           C  
+ANISOU  397  CE2APHE A  13      940   1039   1001     85     -1   -212       C  
+ATOM    398  CE2BPHE A  13       5.069  15.228   8.080  0.51  7.07           C  
+ANISOU  398  CE2BPHE A  13      690   1060    938    102   -189   -144       C  
+ATOM    399  CZ APHE A  13       5.324  13.992   9.265  0.49  7.50           C  
+ANISOU  399  CZ APHE A  13      880   1124    845      3     27   -300       C  
+ATOM    400  CZ BPHE A  13       4.944  14.254   9.017  0.51  7.70           C  
+ANISOU  400  CZ BPHE A  13      969   1092    865      2     74   -502       C  
+ATOM    401  H  APHE A  13      10.930  16.962   7.333  0.49  3.45           H  
+ATOM    402  H  BPHE A  13      10.600  17.028   7.238  0.51  3.45           H  
+ATOM    403  HA APHE A  13       8.917  17.398   8.904  0.49  3.84           H  
+ATOM    404  HA BPHE A  13       8.729  17.325   9.045  0.51  3.84           H  
+ATOM    405  HB2APHE A  13       8.902  15.888   7.020  0.49  2.99           H  
+ATOM    406  HB2BPHE A  13       8.712  15.963   6.998  0.51  2.99           H  
+ATOM    407  HB3APHE A  13       9.714  14.870   7.879  0.49  2.99           H  
+ATOM    408  HB3BPHE A  13       9.391  14.856   7.862  0.51  2.99           H  
+ATOM    409  HD1APHE A  13       8.550  13.646   9.712  0.49  5.08           H  
+ATOM    410  HD1BPHE A  13       8.041  13.775   9.698  0.51  5.08           H  
+ATOM    411  HD2APHE A  13       6.563  16.172   7.330  0.49  5.53           H  
+ATOM    412  HD2BPHE A  13       6.384  16.323   7.099  0.51  5.53           H  
+ATOM    413  HE1APHE A  13       6.523  12.785  10.431  0.49  5.95           H  
+ATOM    414  HE1BPHE A  13       5.921  13.048  10.281  0.51  5.95           H  
+ATOM    415  HE2APHE A  13       4.546  15.287   7.969  0.49  7.07           H  
+ATOM    416  HE2BPHE A  13       4.315  15.590   7.674  0.51  7.07           H  
+ATOM    417  HZ APHE A  13       4.510  13.654   9.562  0.49  7.70           H  
+ATOM    418  HZ BPHE A  13       4.095  13.950   9.243  0.51  7.70           H  
+ATOM    419  N  ATYR A  14      11.103  15.419  10.100  0.52  3.43           N  
+ANISOU  419  N  ATYR A  14      665    301    337    112    202    -17       N  
+ATOM    420  N  BTYR A  14      11.115  15.398  10.058  0.48  4.60           N  
+ANISOU  420  N  BTYR A  14      771    516    460    -21     21   -100       N  
+ATOM    421  CA ATYR A  14      11.627  14.855  11.310  0.52  4.01           C  
+ANISOU  421  CA ATYR A  14      664    430    432     78     53     33       C  
+ATOM    422  CA BTYR A  14      11.689  14.876  11.305  0.48  3.75           C  
+ANISOU  422  CA BTYR A  14      634    373    419      4    118    -42       C  
+ATOM    423  C  ATYR A  14      12.094  15.955  12.243  0.52  3.87           C  
+ANISOU  423  C  ATYR A  14      636    379    455     87     17     21       C  
+ATOM    424  C  BTYR A  14      12.223  15.958  12.260  0.48  3.99           C  
+ANISOU  424  C  BTYR A  14      676    398    441     39     15    -43       C  
+ATOM    425  O  ATYR A  14      11.883  15.878  13.447  0.52  4.20           O  
+ANISOU  425  O  ATYR A  14      646    447    503    114    145     80       O  
+ATOM    426  O  BTYR A  14      12.103  15.832  13.469  0.48  4.04           O  
+ANISOU  426  O  BTYR A  14      706    470    360    -22    -67    -38       O  
+ATOM    427  CB ATYR A  14      12.757  13.879  10.979  0.52  6.88           C  
+ANISOU  427  CB ATYR A  14      970    845    800     77    -93     12       C  
+ATOM    428  CB BTYR A  14      12.787  13.833  11.054  0.48  3.33           C  
+ANISOU  428  CB BTYR A  14      585    247    434    -10     72    -87       C  
+ATOM    429  CG ATYR A  14      12.258  12.477  10.678  0.52  4.29           C  
+ANISOU  429  CG ATYR A  14      734    402    495    151     60     25       C  
+ATOM    430  CG BTYR A  14      12.260  12.445  10.730  0.48  4.38           C  
+ANISOU  430  CG BTYR A  14      778    420    466    104     99    -94       C  
+ATOM    431  CD1ATYR A  14      11.664  12.173   9.476  0.52  3.44           C  
+ANISOU  431  CD1ATYR A  14      611    367    330    -17    117     87       C  
+ATOM    432  CD1BTYR A  14      11.847  11.565  11.734  0.48  4.17           C  
+ANISOU  432  CD1BTYR A  14      704    447    435    161     95    -73       C  
+ATOM    433  CD2ATYR A  14      12.414  11.468  11.600  0.52  4.56           C  
+ANISOU  433  CD2ATYR A  14      761    472    500    145     19    -67       C  
+ATOM    434  CD2BTYR A  14      12.187  12.025   9.430  0.48  6.31           C  
+ANISOU  434  CD2BTYR A  14     1083    713    602     64    362   -109       C  
+ATOM    435  CE1ATYR A  14      11.173  10.898   9.213  0.52  3.40           C  
+ANISOU  435  CE1ATYR A  14      570    406    317     11    141    -85       C  
+ATOM    436  CE1BTYR A  14      11.380  10.281  11.419  0.48  3.75           C  
+ANISOU  436  CE1BTYR A  14      571    379    475      2    135     21       C  
+ATOM    437  CE2ATYR A  14      11.945  10.181  11.352  0.52  4.75           C  
+ANISOU  437  CE2ATYR A  14      807    465    533    176    127    148       C  
+ATOM    438  CE2BTYR A  14      11.706  10.756   9.107  0.48  6.23           C  
+ANISOU  438  CE2BTYR A  14     1127    616    623    -55    293      7       C  
+ATOM    439  CZ ATYR A  14      11.337   9.887  10.147  0.52  4.36           C  
+ANISOU  439  CZ ATYR A  14      820    423    415     38    133    -46       C  
+ATOM    440  CZ BTYR A  14      11.304   9.892  10.114  0.48  4.83           C  
+ANISOU  440  CZ BTYR A  14      944    430    459    -34    165     14       C  
+ATOM    441  OH ATYR A  14      10.888   8.622   9.834  0.52  5.63           O  
+ANISOU  441  OH ATYR A  14     1052    505    581    -87     33   -165       O  
+ATOM    442  OH BTYR A  14      10.840   8.649   9.779  0.48  5.24           O  
+ANISOU  442  OH BTYR A  14     1074    463    454     -8    174    156       O  
+ATOM    443  H  ATYR A  14      11.546  15.221   9.390  0.52  4.60           H  
+ATOM    444  H  BTYR A  14      11.533  15.184   9.337  0.48  4.60           H  
+ATOM    445  HA ATYR A  14      10.928  14.362  11.766  0.52  3.75           H  
+ATOM    446  HA BTYR A  14      10.936  14.451  11.745  0.48  3.75           H  
+ATOM    447  HB2ATYR A  14      13.252  14.212  10.214  0.52  3.33           H  
+ATOM    448  HB2BTYR A  14      13.346  14.136  10.321  0.48  3.33           H  
+ATOM    449  HB3ATYR A  14      13.376  13.844  11.725  0.52  3.33           H  
+ATOM    450  HB3BTYR A  14      13.354  13.778  11.839  0.48  3.33           H  
+ATOM    451  HD1ATYR A  14      11.589  12.833   8.825  0.52  4.17           H  
+ATOM    452  HD1BTYR A  14      11.882  11.835  12.623  0.48  4.17           H  
+ATOM    453  HD2ATYR A  14      12.842  11.649  12.406  0.52  6.31           H  
+ATOM    454  HD2BTYR A  14      12.463  12.596   8.749  0.48  6.31           H  
+ATOM    455  HE1ATYR A  14      10.735  10.724   8.411  0.52  3.75           H  
+ATOM    456  HE1BTYR A  14      11.123   9.698  12.096  0.48  3.75           H  
+ATOM    457  HE2ATYR A  14      12.041   9.519  11.998  0.52  6.23           H  
+ATOM    458  HE2BTYR A  14      11.655  10.490   8.217  0.48  6.23           H  
+ATOM    459  HH ATYR A  14      11.044   8.102  10.475  0.52  5.24           H  
+ATOM    460  HH BTYR A  14      10.853   8.561   8.944  0.48  5.24           H  
+ATOM    461  N  AGLU A  15      12.735  16.976  11.694  0.50  4.03           N  
+ANISOU  461  N  AGLU A  15      628    484    417     13     65      8       N  
+ATOM    462  N  BGLU A  15      12.878  16.984  11.750  0.23  3.04           N  
+ANISOU  462  N  BGLU A  15      488    368    300     26    174   -102       N  
+ATOM    463  N  CGLU A  15      12.889  17.024  11.679  0.27  3.60           N  
+ANISOU  463  N  CGLU A  15      577    394    396     61     67     59       N  
+ATOM    464  CA AGLU A  15      13.212  18.051  12.539  0.50  3.70           C  
+ANISOU  464  CA AGLU A  15      506    478    422      3    -45     47       C  
+ATOM    465  CA BGLU A  15      13.359  18.006  12.666  0.23  3.34           C  
+ANISOU  465  CA BGLU A  15      468    393    408     58    133    -84       C  
+ATOM    466  CA CGLU A  15      13.366  18.053  12.596  0.27  3.69           C  
+ANISOU  466  CA CGLU A  15      529    451    422     22    -23     17       C  
+ATOM    467  C  AGLU A  15      12.024  18.669  13.291  0.50  3.50           C  
+ANISOU  467  C  AGLU A  15      583    357    391    -82     65     19       C  
+ATOM    468  C  BGLU A  15      12.164  18.654  13.363  0.23  3.47           C  
+ANISOU  468  C  BGLU A  15      561    391    366   -104     97    -87       C  
+ATOM    469  C  CGLU A  15      12.195  18.721  13.307  0.27  3.62           C  
+ANISOU  469  C  CGLU A  15      597    388    392      4    -57      1       C  
+ATOM    470  O  AGLU A  15      12.103  18.875  14.508  0.50  4.08           O  
+ANISOU  470  O  AGLU A  15      639    503    409   -100     28    -56       O  
+ATOM    471  O  BGLU A  15      12.179  18.819  14.585  0.23  3.56           O  
+ANISOU  471  O  BGLU A  15      532    435    386    -87    258    -41       O  
+ATOM    472  O  CGLU A  15      12.274  19.027  14.500  0.27  3.82           O  
+ANISOU  472  O  CGLU A  15      682    398    371      1   -126    -76       O  
+ATOM    473  CB AGLU A  15      14.033  19.116  11.774  0.50  4.52           C  
+ANISOU  473  CB AGLU A  15      589    652    477   -114    -45    -72       C  
+ATOM    474  CB BGLU A  15      14.238  19.043  11.972  0.23  4.39           C  
+ANISOU  474  CB BGLU A  15      571    567    529    161     62    -18       C  
+ATOM    475  CB CGLU A  15      14.212  19.111  11.869  0.27  4.04           C  
+ANISOU  475  CB CGLU A  15      550    534    452    -39      7     13       C  
+ATOM    476  CG AGLU A  15      14.653  20.121  12.775  0.50  5.50           C  
+ANISOU  476  CG AGLU A  15      643    802    644   -235    -24    -22       C  
+ATOM    477  CG BGLU A  15      15.593  18.518  11.485  0.23  8.01           C  
+ANISOU  477  CG BGLU A  15      993   1012   1040   -111     66    -67       C  
+ATOM    478  CG CGLU A  15      14.891  20.080  12.837  0.27  6.15           C  
+ANISOU  478  CG CGLU A  15      733    889    714   -137   -183    -31       C  
+ATOM    479  CD AGLU A  15      15.777  21.012  12.284  0.50  5.88           C  
+ANISOU  479  CD AGLU A  15      740    731    765   -125     -9     29       C  
+ATOM    480  CD BGLU A  15      16.460  17.776  12.530  0.23 11.04           C  
+ANISOU  480  CD BGLU A  15     1392   1321   1483   -101    237      4       C  
+ATOM    481  CD CGLU A  15      15.940  20.966  12.196  0.27  5.46           C  
+ANISOU  481  CD CGLU A  15      683    696    697   -186    -87     61       C  
+ATOM    482  OE1AGLU A  15      16.189  20.919  11.120  0.50  6.12           O  
+ANISOU  482  OE1AGLU A  15      715    779    833    -72     91    108       O  
+ATOM    483  OE1BGLU A  15      16.038  16.782  13.181  0.23 10.37           O  
+ANISOU  483  OE1BGLU A  15     1189   1364   1387   -191    239    -47       O  
+ATOM    484  OE1CGLU A  15      15.956  21.113  10.960  0.27  5.33           O  
+ANISOU  484  OE1CGLU A  15      570    709    747    -88    -12    144       O  
+ATOM    485  OE2AGLU A  15      16.276  21.814  13.130  0.50  7.28           O  
+ANISOU  485  OE2AGLU A  15      938    934    893   -380    201   -120       O  
+ATOM    486  OE2BGLU A  15      17.623  18.182  12.668  0.23 12.29           O  
+ANISOU  486  OE2BGLU A  15     1583   1504   1583     -3    189     78       O  
+ATOM    487  OE2CGLU A  15      16.745  21.526  12.969  0.27  6.68           O  
+ANISOU  487  OE2CGLU A  15      846    846    845   -194     93    -95       O  
+ATOM    488  H  AGLU A  15      12.900  17.063  10.855  0.50  3.60           H  
+ATOM    489  H  BGLU A  15      13.050  17.109  10.917  0.23  3.60           H  
+ATOM    490  HA AGLU A  15      13.835  17.672  13.179  0.50  3.69           H  
+ATOM    491  HA BGLU A  15      13.926  17.583  13.329  0.23  3.69           H  
+ATOM    492  HA CGLU A  15      13.930  17.617  13.254  0.27  3.69           H  
+ATOM    493  HB2AGLU A  15      14.734  18.687  11.258  0.50  4.04           H  
+ATOM    494  HB2BGLU A  15      13.754  19.402  11.213  0.23  4.04           H  
+ATOM    495  HB2CGLU A  15      14.887  18.668  11.332  0.27  4.04           H  
+ATOM    496  HB3AGLU A  15      13.463  19.584  11.144  0.50  4.04           H  
+ATOM    497  HB3BGLU A  15      14.392  19.779  12.585  0.23  4.04           H  
+ATOM    498  HB3CGLU A  15      13.647  19.610  11.259  0.27  4.04           H  
+ATOM    499  HG2AGLU A  15      13.941  20.693  13.101  0.50  6.15           H  
+ATOM    500  HG2BGLU A  15      15.436  17.918  10.738  0.23  6.15           H  
+ATOM    501  HG2CGLU A  15      14.213  20.642  13.245  0.27  6.15           H  
+ATOM    502  HG3AGLU A  15      14.983  19.618  13.536  0.50  6.15           H  
+ATOM    503  HG3BGLU A  15      16.105  19.267  11.142  0.23  6.15           H  
+ATOM    504  HG3CGLU A  15      15.305  19.571  13.551  0.27  6.15           H  
+ATOM    505  N  AILE A  16      10.924  18.933  12.590  0.48  2.92           N  
+ANISOU  505  N  AILE A  16      508    317    285      8     16     12       N  
+ATOM    506  N  BILE A  16      11.122  18.997  12.603  0.52  3.75           N  
+ANISOU  506  N  BILE A  16      615    391    421   -124    214    -54       N  
+ATOM    507  CA AILE A  16       9.775  19.534  13.223  0.48  2.98           C  
+ANISOU  507  CA AILE A  16      473    304    357      6    118    -68       C  
+ATOM    508  CA BILE A  16       9.937  19.580  13.211  0.52  4.11           C  
+ANISOU  508  CA BILE A  16      619    463    480      0     61     31       C  
+ATOM    509  C  AILE A  16       9.091  18.603  14.224  0.48  2.92           C  
+ANISOU  509  C  AILE A  16      399    407    305     62     87     90       C  
+ATOM    510  C  BILE A  16       9.351  18.636  14.274  0.52  3.47           C  
+ANISOU  510  C  BILE A  16      412    473    432     54     27   -106       C  
+ATOM    511  O  AILE A  16       8.659  19.053  15.289  0.48  3.11           O  
+ANISOU  511  O  AILE A  16      355    354    471      9     58      8       O  
+ATOM    512  O  BILE A  16       9.000  19.080  15.372  0.52  3.65           O  
+ANISOU  512  O  BILE A  16      406    571    410     20     41    -38       O  
+ATOM    513  CB AILE A  16       8.800  20.020  12.162  0.48  3.40           C  
+ANISOU  513  CB AILE A  16      573    386    332   -113    166    -69       C  
+ATOM    514  CB BILE A  16       8.864  19.978  12.141  0.52  4.21           C  
+ANISOU  514  CB BILE A  16      648    451    500    107    102    115       C  
+ATOM    515  CG1AILE A  16       9.463  21.156  11.378  0.48  5.15           C  
+ANISOU  515  CG1AILE A  16      757    543    654   -173    135    120       C  
+ATOM    516  CG1BILE A  16       9.374  21.122  11.256  0.52  4.72           C  
+ANISOU  516  CG1BILE A  16      765    449    580    167    252     88       C  
+ATOM    517  CG2AILE A  16       7.466  20.431  12.788  0.48  6.01           C  
+ANISOU  517  CG2AILE A  16      771    781    730    -24      8    -79       C  
+ATOM    518  CG2BILE A  16       7.539  20.404  12.795  0.52  3.76           C  
+ANISOU  518  CG2BILE A  16      562    420    448    115    182    145       C  
+ATOM    519  CD1AILE A  16       8.717  21.530  10.143  0.48  7.98           C  
+ANISOU  519  CD1AILE A  16     1020   1055    955   -179    -69    498       C  
+ATOM    520  CD1BILE A  16       8.617  21.257   9.928  0.52  5.65           C  
+ANISOU  520  CD1BILE A  16      884    779    486    114    154    307       C  
+ATOM    521  H  AILE A  16      10.831  18.770  11.751  0.48  3.75           H  
+ATOM    522  H  BILE A  16      11.085  18.901  11.749  0.52  3.75           H  
+ATOM    523  HA AILE A  16      10.089  20.292  13.740  0.48  4.11           H  
+ATOM    524  HA BILE A  16      10.207  20.400  13.653  0.52  4.11           H  
+ATOM    525  HB AILE A  16       8.590  19.302  11.544  0.48  4.21           H  
+ATOM    526  HB BILE A  16       8.705  19.191  11.597  0.52  4.21           H  
+ATOM    527 HG12AILE A  16       9.540  21.935  11.951  0.48  4.72           H  
+ATOM    528 HG12BILE A  16       9.303  21.956  11.746  0.52  4.72           H  
+ATOM    529 HG13AILE A  16      10.365  20.892  11.137  0.48  4.72           H  
+ATOM    530 HG13BILE A  16      10.316  20.982  11.070  0.52  4.72           H  
+ATOM    531 HG21AILE A  16       6.863  20.737  12.093  0.48  3.76           H  
+ATOM    532 HG21BILE A  16       6.900  20.643  12.106  0.52  3.76           H  
+ATOM    533 HG22AILE A  16       7.074  19.670  13.244  0.48  3.76           H  
+ATOM    534 HG22BILE A  16       7.187  19.669  13.321  0.52  3.76           H  
+ATOM    535 HG23AILE A  16       7.614  21.148  13.425  0.48  3.76           H  
+ATOM    536 HG23BILE A  16       7.693  21.169  13.371  0.52  3.76           H  
+ATOM    537 HD11AILE A  16       9.182  22.251   9.690  0.48  5.65           H  
+ATOM    538 HD11BILE A  16       8.987  21.995   9.418  0.52  5.65           H  
+ATOM    539 HD12AILE A  16       8.660  20.762   9.554  0.48  5.65           H  
+ATOM    540 HD12BILE A  16       8.707  20.436   9.419  0.52  5.65           H  
+ATOM    541 HD13AILE A  16       7.823  21.821  10.381  0.48  5.65           H  
+ATOM    542 HD13BILE A  16       7.678  21.426  10.106  0.52  5.65           H  
+ATOM    543  N  ALEU A  17       8.997  17.314  13.910  0.49  3.25           N  
+ANISOU  543  N  ALEU A  17      466    439    328   -109     41    -54       N  
+ATOM    544  N  BLEU A  17       9.258  17.339  13.965  0.51  3.22           N  
+ANISOU  544  N  BLEU A  17      388    413    422     19     72     47       N  
+ATOM    545  CA ALEU A  17       8.475  16.363  14.878  0.49  3.47           C  
+ANISOU  545  CA ALEU A  17      391    491    434    -92     47     58       C  
+ATOM    546  CA BLEU A  17       8.762  16.368  14.941  0.51  3.40           C  
+ANISOU  546  CA BLEU A  17      465    392    434    -72     36     28       C  
+ATOM    547  C  ALEU A  17       9.208  16.446  16.202  0.49  3.64           C  
+ANISOU  547  C  ALEU A  17      489    492    403    -44     27    -21       C  
+ATOM    548  C  BLEU A  17       9.506  16.463  16.263  0.51  2.86           C  
+ANISOU  548  C  BLEU A  17      400    297    391    -94      6     19       C  
+ATOM    549  O  ALEU A  17       8.610  16.207  17.248  0.49  3.62           O  
+ANISOU  549  O  ALEU A  17      498    536    340     27    114    -19       O  
+ATOM    550  O  BLEU A  17       8.943  16.223  17.321  0.51  3.52           O  
+ANISOU  550  O  BLEU A  17      437    431    469   -126     44     42       O  
+ATOM    551  CB ALEU A  17       8.596  14.922  14.381  0.49  3.57           C  
+ANISOU  551  CB ALEU A  17      441    485    431   -155     95     68       C  
+ATOM    552  CB BLEU A  17       8.932  14.922  14.437  0.51  4.07           C  
+ANISOU  552  CB BLEU A  17      628    475    445   -103     45     34       C  
+ATOM    553  CG ALEU A  17       7.576  14.523  13.306  0.49  5.17           C  
+ANISOU  553  CG ALEU A  17      630    715    619   -200    -68     48       C  
+ATOM    554  CG BLEU A  17       7.986  14.429  13.328  0.51  4.11           C  
+ANISOU  554  CG BLEU A  17      734    459    368   -233     32    111       C  
+ATOM    555  CD1ALEU A  17       7.853  13.088  12.939  0.49  5.58           C  
+ANISOU  555  CD1ALEU A  17      691    705    725   -326     56    -45       C  
+ATOM    556  CD1BLEU A  17       8.397  13.008  12.950  0.51  4.53           C  
+ANISOU  556  CD1BLEU A  17      701    472    547   -320     26     -6       C  
+ATOM    557  CD2ALEU A  17       6.136  14.728  13.765  0.49  6.73           C  
+ANISOU  557  CD2ALEU A  17      792    920    845   -118   -181    307       C  
+ATOM    558  CD2BLEU A  17       6.497  14.495  13.701  0.51  5.25           C  
+ANISOU  558  CD2BLEU A  17      733    696    568   -195   -132    120       C  
+ATOM    559  H  ALEU A  17       9.227  16.976  13.153  0.49  3.22           H  
+ATOM    560  H  BLEU A  17       9.475  17.005  13.203  0.51  3.22           H  
+ATOM    561  HA ALEU A  17       7.542  16.599  14.997  0.49  3.40           H  
+ATOM    562  HA BLEU A  17       7.824  16.580  15.065  0.51  3.40           H  
+ATOM    563  HB2ALEU A  17       9.489  14.790  14.026  0.49  4.07           H  
+ATOM    564  HB2BLEU A  17       9.842  14.824  14.117  0.51  4.07           H  
+ATOM    565  HB3ALEU A  17       8.500  14.323  15.138  0.49  4.07           H  
+ATOM    566  HB3BLEU A  17       8.833  14.328  15.198  0.51  4.07           H  
+ATOM    567  HG ALEU A  17       7.674  15.095  12.529  0.49  4.11           H  
+ATOM    568  HG BLEU A  17       8.076  15.029  12.571  0.51  4.11           H  
+ATOM    569 HD11ALEU A  17       7.224  12.801  12.259  0.49  4.53           H  
+ATOM    570 HD11BLEU A  17       7.812  12.677  12.251  0.51  4.53           H  
+ATOM    571 HD12ALEU A  17       8.757  13.010  12.597  0.49  4.53           H  
+ATOM    572 HD12BLEU A  17       9.313  13.010  12.631  0.51  4.53           H  
+ATOM    573 HD13ALEU A  17       7.756  12.528  13.725  0.49  4.53           H  
+ATOM    574 HD13BLEU A  17       8.327  12.433  13.728  0.51  4.53           H  
+ATOM    575 HD21ALEU A  17       5.529  14.464  13.056  0.49  5.25           H  
+ATOM    576 HD21BLEU A  17       5.963  14.171  12.959  0.51  5.25           H  
+ATOM    577 HD22ALEU A  17       5.967  14.188  14.553  0.49  5.25           H  
+ATOM    578 HD22BLEU A  17       6.334  13.943  14.482  0.51  5.25           H  
+ATOM    579 HD23ALEU A  17       5.994  15.663  13.979  0.49  5.25           H  
+ATOM    580 HD23BLEU A  17       6.253  15.413  13.898  0.51  5.25           H  
+ATOM    581  N  AHIS A  18      10.497  16.749  16.144  0.47  4.45           N  
+ANISOU  581  N  AHIS A  18      654    612    425    -57     20     -2       N  
+ATOM    582  N  BHIS A  18      10.793  16.738  16.188  0.53  3.33           N  
+ANISOU  582  N  BHIS A  18      499    396    372     24     54     39       N  
+ATOM    583  CA AHIS A  18      11.371  16.610  17.285  0.47  4.98           C  
+ANISOU  583  CA AHIS A  18      668    653    571     32    -77     -4       C  
+ATOM    584  CA BHIS A  18      11.674  16.588  17.313  0.53  3.38           C  
+ANISOU  584  CA BHIS A  18      493    414    378      3    -89     18       C  
+ATOM    585  C  AHIS A  18      11.823  17.916  17.954  0.47  4.43           C  
+ANISOU  585  C  AHIS A  18      634    609    440    -19    -67     48       C  
+ATOM    586  C  BHIS A  18      12.153  17.897  17.943  0.53  4.22           C  
+ANISOU  586  C  BHIS A  18      549    514    542    -23    102    -73       C  
+ATOM    587  O  AHIS A  18      12.476  17.859  18.980  0.47  4.70           O  
+ANISOU  587  O  AHIS A  18      620    701    466     -2   -110     61       O  
+ATOM    588  O  BHIS A  18      12.907  17.872  18.912  0.53  4.80           O  
+ANISOU  588  O  BHIS A  18      587    676    559    -42   -194   -113       O  
+ATOM    589  CB AHIS A  18      12.561  15.728  16.894  0.47  5.69           C  
+ANISOU  589  CB AHIS A  18      742    715    705     55     -3     14       C  
+ATOM    590  CB BHIS A  18      12.846  15.724  16.902  0.53  4.14           C  
+ANISOU  590  CB BHIS A  18      487    514    571    -17   -188      9       C  
+ATOM    591  CG AHIS A  18      12.143  14.340  16.513  0.47  4.60           C  
+ANISOU  591  CG AHIS A  18      604    512    632    154     13      0       C  
+ATOM    592  CG BHIS A  18      12.435  14.342  16.510  0.53  4.24           C  
+ANISOU  592  CG BHIS A  18      573    477    562     76   -107    103       C  
+ATOM    593  ND1AHIS A  18      12.783  13.611  15.548  0.47  5.18           N  
+ANISOU  593  ND1AHIS A  18      714    517    737    -86    170      3       N  
+ATOM    594  ND1BHIS A  18      13.182  13.573  15.661  0.53  5.20           N  
+ANISOU  594  ND1BHIS A  18      643    617    718     42    -73     -9       N  
+ATOM    595  CD2AHIS A  18      11.124  13.564  16.947  0.47  4.76           C  
+ANISOU  595  CD2AHIS A  18      662    442    706    -35    111    -45       C  
+ATOM    596  CD2BHIS A  18      11.353  13.593  16.838  0.53  5.49           C  
+ANISOU  596  CD2BHIS A  18      763    639    683     41      7    124       C  
+ATOM    597  CE1AHIS A  18      12.180  12.448  15.411  0.47  5.25           C  
+ANISOU  597  CE1AHIS A  18      761    629    604    -15    174    -18       C  
+ATOM    598  CE1BHIS A  18      12.580  12.415  15.486  0.53  5.13           C  
+ANISOU  598  CE1BHIS A  18      746    608    595    101    -35    -81       C  
+ATOM    599  NE2AHIS A  18      11.163  12.385  16.246  0.47  3.71           N  
+ANISOU  599  NE2AHIS A  18      563    427    420     -7     17     68       N  
+ATOM    600  NE2BHIS A  18      11.470  12.387  16.192  0.53  5.23           N  
+ANISOU  600  NE2BHIS A  18      872    395    720    -15    -28      6       N  
+ATOM    601  H  AHIS A  18      10.887  17.042  15.436  0.47  3.33           H  
+ATOM    602  H  BHIS A  18      11.180  17.020  15.473  0.53  3.33           H  
+ATOM    603  HA AHIS A  18      10.841  16.188  17.979  0.47  3.38           H  
+ATOM    604  HA BHIS A  18      11.156  16.163  18.015  0.53  3.38           H  
+ATOM    605  HB2AHIS A  18      13.033  16.136  16.151  0.47  4.14           H  
+ATOM    606  HB2BHIS A  18      13.307  16.143  16.159  0.53  4.14           H  
+ATOM    607  HB3AHIS A  18      13.185  15.683  17.636  0.47  4.14           H  
+ATOM    608  HB3BHIS A  18      13.478  15.673  17.636  0.53  4.14           H  
+ATOM    609  HD1BHIS A  18      13.926  13.808  15.299  0.53  5.20           H  
+ATOM    610  HD2AHIS A  18      10.506  13.790  17.604  0.47  5.49           H  
+ATOM    611  HD2BHIS A  18      10.657  13.850  17.399  0.53  5.49           H  
+ATOM    612  HE1AHIS A  18      12.432  11.777  14.818  0.47  5.13           H  
+ATOM    613  HE1BHIS A  18      12.891  11.724  14.947  0.53  5.13           H  
+ATOM    614  HE2AHIS A  18      10.621  11.724  16.336  0.47  5.23           H  
+ATOM    615  N  ALEU A  19      11.489  19.079  17.398  0.49  4.57           N  
+ANISOU  615  N  ALEU A  19      638    633    464     12   -139     66       N  
+ATOM    616  N  BLEU A  19      11.702  19.041  17.425  0.51  3.40           N  
+ANISOU  616  N  BLEU A  19      611    392    289     43     82    -94       N  
+ATOM    617  CA ALEU A  19      11.906  20.347  18.004  0.49  4.25           C  
+ANISOU  617  CA ALEU A  19      654    544    417    -73     48     -5       C  
+ATOM    618  CA BLEU A  19      12.153  20.305  18.013  0.51  3.84           C  
+ANISOU  618  CA BLEU A  19      629    515    315    -26     75    -67       C  
+ATOM    619  C  ALEU A  19      11.429  20.379  19.446  0.49  4.57           C  
+ANISOU  619  C  ALEU A  19      652    613    471    -63    136    -93       C  
+ATOM    620  C  BLEU A  19      11.675  20.339  19.465  0.51  3.78           C  
+ANISOU  620  C  BLEU A  19      554    531    351     44    -33    -69       C  
+ATOM    621  O  ALEU A  19      10.233  20.283  19.698  0.49  4.84           O  
+ANISOU  621  O  ALEU A  19      643    713    484    -88     94    -73       O  
+ATOM    622  O  BLEU A  19      10.507  20.074  19.742  0.51  4.62           O  
+ANISOU  622  O  BLEU A  19      616    690    448      2     -7    -83       O  
+ATOM    623  CB ALEU A  19      11.357  21.544  17.226  0.49  3.80           C  
+ANISOU  623  CB ALEU A  19      579    468    396    -39    120    -38       C  
+ATOM    624  CB BLEU A  19      11.631  21.519  17.237  0.51  4.65           C  
+ANISOU  624  CB BLEU A  19      684    654    429     70    -55   -147       C  
+ATOM    625  CG ALEU A  19      12.050  21.864  15.906  0.49  4.43           C  
+ANISOU  625  CG ALEU A  19      634    586    463     15      2    -80       C  
+ATOM    626  CG BLEU A  19      12.389  21.828  15.942  0.51  4.58           C  
+ANISOU  626  CG BLEU A  19      750    588    401    -54     97    -35       C  
+ATOM    627  CD1ALEU A  19      11.188  22.816  15.083  0.49  3.70           C  
+ANISOU  627  CD1ALEU A  19      611    431    364    -52     67     -6       C  
+ATOM    628  CD1BLEU A  19      11.641  22.824  15.065  0.51  5.47           C  
+ANISOU  628  CD1BLEU A  19      784    737    556    -66     33    -23       C  
+ATOM    629  CD2ALEU A  19      13.401  22.484  16.118  0.49  6.49           C  
+ANISOU  629  CD2ALEU A  19      859    943    663    105     -3    -61       C  
+ATOM    630  CD2BLEU A  19      13.735  22.391  16.228  0.51  4.17           C  
+ANISOU  630  CD2BLEU A  19      549    603    431   -130    170    -42       C  
+ATOM    631  H  ALEU A  19      11.026  19.158  16.677  0.49  3.40           H  
+ATOM    632  H  BLEU A  19      11.158  19.109  16.762  0.51  3.40           H  
+ATOM    633  HA ALEU A  19      12.874  20.409  17.977  0.49  3.84           H  
+ATOM    634  HA BLEU A  19      13.121  20.354  17.971  0.51  3.84           H  
+ATOM    635  HB2ALEU A  19      10.417  21.386  17.046  0.49  4.65           H  
+ATOM    636  HB2BLEU A  19      10.696  21.373  17.023  0.51  4.65           H  
+ATOM    637  HB3ALEU A  19      11.409  22.328  17.795  0.49  4.65           H  
+ATOM    638  HB3BLEU A  19      11.671  22.298  17.814  0.51  4.65           H  
+ATOM    639  HG ALEU A  19      12.171  21.026  15.433  0.49  4.58           H  
+ATOM    640  HG BLEU A  19      12.471  20.983  15.472  0.51  4.58           H  
+ATOM    641 HD11ALEU A  19      11.635  23.015  14.245  0.49  5.47           H  
+ATOM    642 HD11BLEU A  19      12.152  22.992  14.258  0.51  5.47           H  
+ATOM    643 HD12ALEU A  19      10.330  22.401  14.901  0.49  5.47           H  
+ATOM    644 HD12BLEU A  19      10.774  22.459  14.828  0.51  5.47           H  
+ATOM    645 HD13ALEU A  19      11.050  23.638  15.579  0.49  5.47           H  
+ATOM    646 HD13BLEU A  19      11.520  23.655  15.550  0.51  5.47           H  
+ATOM    647 HD21ALEU A  19      13.809  22.673  15.259  0.49  4.17           H  
+ATOM    648 HD21BLEU A  19      14.192  22.577  15.393  0.51  4.17           H  
+ATOM    649 HD22ALEU A  19      13.303  23.310  16.617  0.49  4.17           H  
+ATOM    650 HD22BLEU A  19      13.641  23.213  16.735  0.51  4.17           H  
+ATOM    651 HD23ALEU A  19      13.964  21.871  16.615  0.49  4.17           H  
+ATOM    652 HD23BLEU A  19      14.251  21.751  16.743  0.51  4.17           H  
+ATOM    653  N  APRO A  20      12.357  20.543  20.408  0.51  4.36           N  
+ANISOU  653  N  APRO A  20      628    613    416      2     54   -116       N  
+ATOM    654  N  BPRO A  20      12.574  20.665  20.406  0.49  4.55           N  
+ANISOU  654  N  BPRO A  20      736    627    365    -50     -9    -63       N  
+ATOM    655  CA APRO A  20      11.955  20.236  21.794  0.51  4.43           C  
+ANISOU  655  CA APRO A  20      729    646    309     44     91    -47       C  
+ATOM    656  CA BPRO A  20      12.259  20.447  21.823  0.49  5.54           C  
+ANISOU  656  CA BPRO A  20      861    779    463    -89    -26     28       C  
+ATOM    657  C  APRO A  20      11.078  21.281  22.450  0.51  3.71           C  
+ANISOU  657  C  APRO A  20      593    612    204    -19    119    -61       C  
+ATOM    658  C  BPRO A  20      11.236  21.419  22.409  0.49  5.89           C  
+ANISOU  658  C  BPRO A  20      796    853    589   -125     -4     58       C  
+ATOM    659  O  APRO A  20      10.424  20.944  23.458  0.51  5.44           O  
+ANISOU  659  O  APRO A  20      841    901    324    -69    120    -21       O  
+ATOM    660  O  BPRO A  20      10.484  21.050  23.291  0.49  7.75           O  
+ANISOU  660  O  BPRO A  20     1118    989    837   -132    426     72       O  
+ATOM    661  CB APRO A  20      13.299  20.142  22.538  0.51  4.68           C  
+ANISOU  661  CB APRO A  20      698    736    344     29     20   -126       C  
+ATOM    662  CB BPRO A  20      13.622  20.603  22.513  0.49  6.91           C  
+ANISOU  662  CB BPRO A  20      945    986    695   -142   -336    -68       C  
+ATOM    663  CG APRO A  20      14.254  20.933  21.718  0.51  6.76           C  
+ANISOU  663  CG APRO A  20      788    934    845     44   -156   -143       C  
+ATOM    664  CG BPRO A  20      14.408  21.400  21.611  0.49  5.24           C  
+ANISOU  664  CG BPRO A  20      585    739    667   -131    -79   -152       C  
+ATOM    665  CD APRO A  20      13.822  20.691  20.286  0.51  5.27           C  
+ANISOU  665  CD APRO A  20      657    769    578     91     15   -226       C  
+ATOM    666  CD BPRO A  20      14.000  20.962  20.228  0.49  5.40           C  
+ANISOU  666  CD BPRO A  20      646    801    604    -63    -61   -112       C  
+ATOM    667  HA APRO A  20      11.412  19.433  21.816  0.51  5.54           H  
+ATOM    668  HA BPRO A  20      11.837  19.583  21.952  0.49  5.54           H  
+ATOM    669  HB2APRO A  20      13.228  20.500  23.437  0.51  6.91           H  
+ATOM    670  HB2BPRO A  20      13.531  21.036  23.376  0.49  6.91           H  
+ATOM    671  HB3APRO A  20      13.589  19.220  22.622  0.51  6.91           H  
+ATOM    672  HB3BPRO A  20      14.036  19.740  22.671  0.49  6.91           H  
+ATOM    673  HG2APRO A  20      14.216  21.876  21.943  0.51  5.24           H  
+ATOM    674  HG2BPRO A  20      14.238  22.346  21.742  0.49  5.24           H  
+ATOM    675  HG3APRO A  20      15.168  20.643  21.864  0.51  5.24           H  
+ATOM    676  HG3BPRO A  20      15.357  21.259  21.756  0.49  5.24           H  
+ATOM    677  HD2APRO A  20      14.062  21.431  19.707  0.51  5.40           H  
+ATOM    678  HD2BPRO A  20      14.146  21.659  19.569  0.49  5.40           H  
+ATOM    679  HD3APRO A  20      14.235  19.895  19.915  0.51  5.40           H  
+ATOM    680  HD3BPRO A  20      14.498  20.184  19.932  0.49  5.40           H  
+ATOM    681  N  AASN A  21      11.073  22.509  21.951  0.52  3.90           N  
+ANISOU  681  N  AASN A  21      461    677    345     15    139   -106       N  
+ATOM    682  N  BASN A  21      11.207  22.657  21.929  0.48  5.18           N  
+ANISOU  682  N  BASN A  21      760    805    403   -101   -109    -12       N  
+ATOM    683  CA AASN A  21      10.440  23.591  22.686  0.52  4.81           C  
+ANISOU  683  CA AASN A  21      633    805    389     62    100   -140       C  
+ATOM    684  CA BASN A  21      10.480  23.726  22.616  0.48  4.93           C  
+ANISOU  684  CA BASN A  21      719    721    433    -62    -13    -63       C  
+ATOM    685  C  AASN A  21       9.112  24.052  22.091  0.52  5.28           C  
+ANISOU  685  C  AASN A  21      712    758    534    -11    249    -21       C  
+ATOM    686  C  BASN A  21       9.193  24.165  21.972  0.48  5.46           C  
+ANISOU  686  C  BASN A  21      834    581    658   -140   -129   -134       C  
+ATOM    687  O  AASN A  21       8.444  24.904  22.666  0.52  6.14           O  
+ANISOU  687  O  AASN A  21      857    883    592     98     55    -94       O  
+ATOM    688  O  BASN A  21       8.645  25.174  22.379  0.48  7.18           O  
+ANISOU  688  O  BASN A  21     1111    663    954     31    -28    -44       O  
+ATOM    689  CB AASN A  21      11.433  24.728  22.862  0.52  6.01           C  
+ANISOU  689  CB AASN A  21      834    912    536     12     77   -163       C  
+ATOM    690  CB BASN A  21      11.364  24.940  22.799  0.48  4.59           C  
+ANISOU  690  CB BASN A  21      680    669    397   -110    -29   -188       C  
+ATOM    691  CG AASN A  21      12.737  24.230  23.427  0.52  5.67           C  
+ANISOU  691  CG AASN A  21      796    794    563     17    -58   -278       C  
+ATOM    692  CG BASN A  21      12.677  24.579  23.389  0.48  5.46           C  
+ANISOU  692  CG BASN A  21      755    818    502   -102    -98   -191       C  
+ATOM    693  OD1AASN A  21      12.747  23.429  24.357  0.52  6.14           O  
+ANISOU  693  OD1AASN A  21      873    808    653     15   -176    -86       O  
+ATOM    694  OD1BASN A  21      12.752  23.883  24.398  0.48  6.80           O  
+ANISOU  694  OD1BASN A  21      869    987    729   -170   -263    -45       O  
+ATOM    695  ND2AASN A  21      13.844  24.641  22.843  0.52  5.78           N  
+ANISOU  695  ND2AASN A  21      811    780    607    143     13   -213       N  
+ATOM    696  ND2BASN A  21      13.745  25.055  22.786  0.48  5.65           N  
+ANISOU  696  ND2BASN A  21      740    818    590   -155     -6   -182       N  
+ATOM    697  H  AASN A  21      11.425  22.734  21.200  0.52  5.18           H  
+ATOM    698  H  BASN A  21      11.602  22.902  21.205  0.48  5.18           H  
+ATOM    699  HA AASN A  21      10.195  23.249  23.560  0.52  4.93           H  
+ATOM    700  HA BASN A  21      10.233  23.328  23.465  0.48  4.93           H  
+ATOM    701  HB2AASN A  21      11.591  25.158  22.007  0.52  4.59           H  
+ATOM    702  HB2BASN A  21      11.502  25.372  21.942  0.48  4.59           H  
+ATOM    703  HB3AASN A  21      11.058  25.400  23.452  0.52  4.59           H  
+ATOM    704  HB3BASN A  21      10.917  25.583  23.372  0.48  4.59           H  
+ATOM    705 HD21AASN A  21      14.606  24.347  23.111  0.52  5.65           H  
+ATOM    706 HD21BASN A  21      14.528  24.881  23.097  0.48  5.65           H  
+ATOM    707 HD22AASN A  21      13.804  25.203  22.193  0.52  5.65           H  
+ATOM    708 HD22BASN A  21      13.660  25.540  22.081  0.48  5.65           H  
+ATOM    709  N  ALEU A  22       8.697  23.455  20.979  0.32  4.67           N  
+ANISOU  709  N  ALEU A  22      661    717    396     78    196   -121       N  
+ATOM    710  N  BLEU A  22       8.668  23.395  21.029  0.68  4.77           N  
+ANISOU  710  N  BLEU A  22      600    650    561     36    -42    -21       N  
+ATOM    711  CA  LEU A  22       7.358  23.710  20.474  1.00  4.33           C  
+ANISOU  711  CA  LEU A  22      543    596    505      2     86     29       C  
+ATOM    712  C   LEU A  22       6.287  23.120  21.375  1.00  4.64           C  
+ANISOU  712  C   LEU A  22      594    716    454     13     95    104       C  
+ATOM    713  O   LEU A  22       6.464  22.040  21.958  1.00  7.04           O  
+ANISOU  713  O   LEU A  22      809    933    932    127    288    428       O  
+ATOM    714  CB  LEU A  22       7.179  23.122  19.075  1.00  4.08           C  
+ANISOU  714  CB  LEU A  22      509    527    516    -45     71     45       C  
+ATOM    715  CG  LEU A  22       8.131  23.664  18.012  1.00  4.54           C  
+ANISOU  715  CG  LEU A  22      610    641    474    -95     77     -7       C  
+ATOM    716  CD1 LEU A  22       7.759  23.040  16.668  1.00  5.32           C  
+ANISOU  716  CD1 LEU A  22      767    782    473   -139    138     22       C  
+ATOM    717  CD2 LEU A  22       8.097  25.175  17.920  1.00  4.96           C  
+ANISOU  717  CD2 LEU A  22      682    615    589    -91    204     74       C  
+ATOM    718  H  ALEU A  22       9.167  22.908  20.510  0.32  4.77           H  
+ATOM    719  H  BLEU A  22       9.046  22.696  20.700  0.68  4.77           H  
+ATOM    720  HA ALEU A  22       7.257  24.674  20.449  0.32  4.33           H  
+ATOM    721  HA BLEU A  22       7.283  24.675  20.417  0.68  4.33           H  
+ATOM    722  HB2 LEU A  22       7.291  22.160  19.128  1.00  4.08           H  
+ATOM    723  HB3 LEU A  22       6.268  23.286  18.786  1.00  4.08           H  
+ATOM    724  HG  LEU A  22       9.038  23.425  18.261  1.00  4.54           H  
+ATOM    725 HD11 LEU A  22       8.355  23.374  15.980  1.00  5.32           H  
+ATOM    726 HD12 LEU A  22       7.841  22.075  16.725  1.00  5.32           H  
+ATOM    727 HD13 LEU A  22       6.845  23.274  16.444  1.00  5.32           H  
+ATOM    728 HD21 LEU A  22       8.715  25.472  17.234  1.00  4.96           H  
+ATOM    729 HD22 LEU A  22       7.200  25.465  17.693  1.00  4.96           H  
+ATOM    730 HD23 LEU A  22       8.354  25.557  18.774  1.00  4.96           H  
+ATOM    731  N   THR A  23       5.151  23.807  21.472  1.00  4.62           N  
+ANISOU  731  N   THR A  23      631    711    411    -25    159     90       N  
+ATOM    732  CA  THR A  23       3.968  23.196  22.025  1.00  4.41           C  
+ANISOU  732  CA  THR A  23      691    651    335    -65    193     89       C  
+ATOM    733  C  ATHR A  23       3.408  22.242  21.011  0.38  3.63           C  
+ANISOU  733  C  ATHR A  23      528    554    298     87    205      7       C  
+ATOM    734  C  BTHR A  23       3.361  22.161  21.020  0.56  4.64           C  
+ANISOU  734  C  BTHR A  23      705    661    398    -82    199    196       C  
+ATOM    735  C  CTHR A  23       3.436  22.251  20.991  0.05  6.23           C  
+ANISOU  735  C  CTHR A  23     1043    928    398     -9    270     91       C  
+ATOM    736  O  ATHR A  23       3.712  22.346  19.825  0.38  3.87           O  
+ANISOU  736  O  ATHR A  23      599    620    251     61    162     73       O  
+ATOM    737  O  BTHR A  23       3.707  22.160  19.833  0.56  4.37           O  
+ANISOU  737  O  BTHR A  23      612    662    388    -18    271     61       O  
+ATOM    738  O  CTHR A  23       3.728  22.397  19.804  0.05  7.29           O  
+ANISOU  738  O  CTHR A  23     1239    974    559    -10    192     94       O  
+ATOM    739  CB  THR A  23       2.899  24.237  22.355  1.00  4.70           C  
+ANISOU  739  CB  THR A  23      667    684    435    -57    305      2       C  
+ATOM    740  OG1 THR A  23       2.401  24.735  21.124  1.00  4.54           O  
+ANISOU  740  OG1 THR A  23      643    649    433     12    253     -1       O  
+ATOM    741  CG2 THR A  23       3.422  25.360  23.248  1.00  6.14           C  
+ANISOU  741  CG2 THR A  23      970    843    522     36    197   -113       C  
+ATOM    742  H   THR A  23       5.053  24.624  21.222  1.00  4.62           H  
+ATOM    743  HA ATHR A  23       4.213  22.740  22.845  0.38  4.41           H  
+ATOM    744  HA BTHR A  23       4.237  22.748  22.842  0.56  4.41           H  
+ATOM    745  HA CTHR A  23       4.193  22.739  22.851  0.05  4.41           H  
+ATOM    746  HB  THR A  23       2.189  23.820  22.868  1.00  4.70           H  
+ATOM    747  HG1 THR A  23       1.775  25.275  21.273  1.00  4.54           H  
+ATOM    748 HG21 THR A  23       2.707  25.991  23.427  1.00  6.14           H  
+ATOM    749 HG22 THR A  23       3.740  24.987  24.085  1.00  6.14           H  
+ATOM    750 HG23 THR A  23       4.151  25.817  22.800  1.00  6.14           H  
+ATOM    751  N  AGLU A  24       2.579  21.310  21.453  0.44  5.49           N  
+ANISOU  751  N  AGLU A  24      859    864    365    -63    200     33       N  
+ATOM    752  N  BGLU A  24       2.449  21.310  21.501  0.38  3.59           N  
+ANISOU  752  N  BGLU A  24      620    450    293    -78    184     67       N  
+ATOM    753  N  CGLU A  24       2.663  21.269  21.423  0.18  6.82           N  
+ANISOU  753  N  CGLU A  24      981   1026    582   -118    188    102       N  
+ATOM    754  CA AGLU A  24       2.054  20.387  20.456  0.44  5.33           C  
+ANISOU  754  CA AGLU A  24      783    672    571   -190    324     51       C  
+ATOM    755  CA BGLU A  24       1.742  20.337  20.642  0.38  5.04           C  
+ANISOU  755  CA BGLU A  24      927    593    394   -252    153     12       C  
+ATOM    756  CA CGLU A  24       2.167  20.310  20.456  0.18  5.70           C  
+ANISOU  756  CA CGLU A  24      774    768    625   -166    353     82       C  
+ATOM    757  C  AGLU A  24       1.079  21.091  19.468  0.44  4.99           C  
+ANISOU  757  C  AGLU A  24      631    746    520   -177    284     56       C  
+ATOM    758  C  BGLU A  24       1.101  21.044  19.503  0.38  4.56           C  
+ANISOU  758  C  BGLU A  24      699    672    360   -271    200    -60       C  
+ATOM    759  C  CGLU A  24       1.163  20.952  19.489  0.18  5.02           C  
+ANISOU  759  C  CGLU A  24      634    788    485   -152    273     95       C  
+ATOM    760  O  AGLU A  24       1.021  20.681  18.297  0.44  4.82           O  
+ANISOU  760  O  AGLU A  24      629    748    456   -166    235    125       O  
+ATOM    761  O  BGLU A  24       1.274  20.652  18.340  0.38  4.49           O  
+ANISOU  761  O  BGLU A  24      687    637    382   -346    158   -175       O  
+ATOM    762  O  CGLU A  24       1.038  20.496  18.347  0.18  4.75           O  
+ANISOU  762  O  CGLU A  24      570    800    435   -198    197     92       O  
+ATOM    763  CB AGLU A  24       1.478  19.126  21.107  0.44  5.27           C  
+ANISOU  763  CB AGLU A  24      650    664    686   -176    298    114       C  
+ATOM    764  CB BGLU A  24       0.671  19.556  21.407  0.38  6.80           C  
+ANISOU  764  CB BGLU A  24     1026    910    649   -320    115    126       C  
+ATOM    765  CB CGLU A  24       1.620  19.068  21.163  0.18  5.56           C  
+ANISOU  765  CB CGLU A  24      711    712    691   -153    331    117       C  
+ATOM    766  CG AGLU A  24       2.484  18.324  21.954  0.44  7.89           C  
+ANISOU  766  CG AGLU A  24     1032   1067    900   -209    243    149       C  
+ATOM    767  CG BGLU A  24       1.273  18.490  22.315  0.38  9.74           C  
+ANISOU  767  CG BGLU A  24     1353   1126   1222   -266    221    145       C  
+ATOM    768  CG CGLU A  24       2.676  18.373  22.019  0.18  7.12           C  
+ANISOU  768  CG CGLU A  24      941    897    866   -100    332    125       C  
+ATOM    769  CD AGLU A  24       3.810  18.018  21.230  0.44  7.60           C  
+ANISOU  769  CD AGLU A  24     1077    944    866   -113     83     58       C  
+ATOM    770  CD BGLU A  24       1.692  17.231  21.560  0.38 11.83           C  
+ANISOU  770  CD BGLU A  24     1698   1136   1660   -250    277    235       C  
+ATOM    771  CD CGLU A  24       4.044  18.333  21.329  0.18  8.39           C  
+ANISOU  771  CD CGLU A  24     1131   1047   1010    -46    224    189       C  
+ATOM    772  OE1AGLU A  24       3.786  17.659  20.047  0.44  6.97           O  
+ANISOU  772  OE1AGLU A  24      873    839    935   -112    181     96       O  
+ATOM    773  OE1BGLU A  24       1.210  17.035  20.434  0.38 13.52           O  
+ANISOU  773  OE1BGLU A  24     1956   1258   1924   -261    474    160       O  
+ATOM    774  OE1CGLU A  24       4.175  17.576  20.352  0.18  8.04           O  
+ANISOU  774  OE1CGLU A  24     1001   1001   1052   -142    308    252       O  
+ATOM    775  OE2AGLU A  24       4.903  18.161  21.851  0.44  8.22           O  
+ANISOU  775  OE2AGLU A  24     1031   1195    897    -30    145    129       O  
+ATOM    776  OE2BGLU A  24       2.459  16.410  22.115  0.38 13.63           O  
+ANISOU  776  OE2BGLU A  24     1873   1344   1962   -171    252    189       O  
+ATOM    777  OE2CGLU A  24       4.974  19.071  21.741  0.18  8.88           O  
+ANISOU  777  OE2CGLU A  24     1211   1175    987     72    195    117       O  
+ATOM    778  H  AGLU A  24       2.320  21.195  22.265  0.44  6.82           H  
+ATOM    779  H  BGLU A  24       2.220  21.277  22.329  0.38  6.82           H  
+ATOM    780  H  CGLU A  24       2.421  21.142  22.239  0.18  6.82           H  
+ATOM    781  HA AGLU A  24       2.795  20.084  19.908  0.44  5.70           H  
+ATOM    782  HA BGLU A  24       2.404  19.704  20.323  0.38  5.70           H  
+ATOM    783  HA CGLU A  24       2.907  20.013  19.904  0.18  5.70           H  
+ATOM    784  HB2AGLU A  24       0.730  19.380  21.670  0.44  5.56           H  
+ATOM    785  HB2BGLU A  24       0.143  20.171  21.939  0.38  5.56           H  
+ATOM    786  HB2CGLU A  24       0.869  19.322  21.723  0.18  5.56           H  
+ATOM    787  HB3AGLU A  24       1.127  18.549  20.411  0.44  5.56           H  
+ATOM    788  HB3BGLU A  24       0.066  19.136  20.775  0.38  5.56           H  
+ATOM    789  HB3CGLU A  24       1.282  18.445  20.501  0.18  5.56           H  
+ATOM    790  HG2AGLU A  24       2.676  18.819  22.766  0.44  7.12           H  
+ATOM    791  HG2BGLU A  24       2.045  18.859  22.771  0.38  7.12           H  
+ATOM    792  HG2CGLU A  24       2.757  18.835  22.868  0.18  7.12           H  
+ATOM    793  HG3AGLU A  24       2.072  17.488  22.222  0.44  7.12           H  
+ATOM    794  HG3BGLU A  24       0.627  18.252  22.998  0.38  7.12           H  
+ATOM    795  HG3CGLU A  24       2.387  17.468  22.215  0.18  7.12           H  
+ATOM    796  N  AGLU A  25       0.362  22.158  19.867  0.44  5.01           N  
+ANISOU  796  N  AGLU A  25      675    815    414   -142    259     42       N  
+ATOM    797  N  BGLU A  25       0.324  22.069  19.813  0.38  4.17           N  
+ANISOU  797  N  BGLU A  25      560    668    358   -185    204     -8       N  
+ATOM    798  N  CGLU A  25       0.493  22.034  19.898  0.18  4.72           N  
+ANISOU  798  N  CGLU A  25      632    749    413   -112    269     35       N  
+ATOM    799  CA AGLU A  25      -0.454  22.929  18.901  0.44  5.39           C  
+ANISOU  799  CA AGLU A  25      556    926    566    -67    229     -7       C  
+ATOM    800  CA BGLU A  25      -0.445  22.725  18.790  0.38  4.13           C  
+ANISOU  800  CA BGLU A  25      479    749    341   -166    171   -135       C  
+ATOM    801  CA CGLU A  25      -0.356  22.801  18.956  0.18  4.79           C  
+ANISOU  801  CA CGLU A  25      518    748    552    -47    220    -60       C  
+ATOM    802  C  AGLU A  25       0.434  23.477  17.803  0.44  4.35           C  
+ANISOU  802  C  AGLU A  25      509    704    438    -25    167    -66       C  
+ATOM    803  C  BGLU A  25       0.478  23.411  17.766  0.38  3.83           C  
+ANISOU  803  C  BGLU A  25      478    595    383    -54    232    -93       C  
+ATOM    804  C  CGLU A  25       0.506  23.362  17.833  0.18  4.30           C  
+ANISOU  804  C  CGLU A  25      519    661    455     -4    142    -76       C  
+ATOM    805  O  AGLU A  25       0.090  23.457  16.621  0.44  4.56           O  
+ANISOU  805  O  AGLU A  25      526    803    405     44    124     72       O  
+ATOM    806  O  BGLU A  25       0.225  23.367  16.565  0.38  3.98           O  
+ANISOU  806  O  BGLU A  25      510    594    407   -111    250    -54       O  
+ATOM    807  O  CGLU A  25       0.218  23.203  16.657  0.18  4.22           O  
+ANISOU  807  O  CGLU A  25      454    724    425    -81     90    -67       O  
+ATOM    808  CB AGLU A  25      -1.205  24.103  19.588  0.44  6.47           C  
+ANISOU  808  CB AGLU A  25      677   1093    688     -3    169   -239       C  
+ATOM    809  CB BGLU A  25      -1.379  23.705  19.501  0.38  5.15           C  
+ANISOU  809  CB BGLU A  25      576    888    494     -5    263   -104       C  
+ATOM    810  CB CGLU A  25      -1.104  23.977  19.644  0.18  6.73           C  
+ANISOU  810  CB CGLU A  25      749   1021    785     38    126   -231       C  
+ATOM    811  CG AGLU A  25      -1.903  25.034  18.604  0.44  8.06           C  
+ANISOU  811  CG AGLU A  25      924   1297    840    238     35   -353       C  
+ATOM    812  CG BGLU A  25      -2.240  24.505  18.583  0.38  7.55           C  
+ANISOU  812  CG BGLU A  25      928   1137    803     57    227     -4       C  
+ATOM    813  CG CGLU A  25      -1.869  24.909  18.652  0.18  8.51           C  
+ANISOU  813  CG CGLU A  25      985   1277    971    225     -4   -297       C  
+ATOM    814  CD AGLU A  25      -2.573  26.200  19.268  0.44  8.89           C  
+ANISOU  814  CD AGLU A  25      895   1506    977    444    -67   -187       C  
+ATOM    815  CD BGLU A  25      -1.622  25.807  18.133  0.38  9.87           C  
+ANISOU  815  CD BGLU A  25     1166   1424   1159    130      2    -30       C  
+ATOM    816  CD CGLU A  25      -2.310  26.249  19.245  0.18  9.39           C  
+ANISOU  816  CD CGLU A  25      980   1517   1070    394    -59   -223       C  
+ATOM    817  OE1AGLU A  25      -1.956  26.827  20.151  0.44  8.68           O  
+ANISOU  817  OE1AGLU A  25      874   1492    930    380     36   -175       O  
+ATOM    818  OE1BGLU A  25      -0.729  26.344  18.811  0.38 10.17           O  
+ANISOU  818  OE1BGLU A  25     1143   1441   1281     24     52     14       O  
+ATOM    819  OE1CGLU A  25      -1.834  26.615  20.342  0.18  9.14           O  
+ANISOU  819  OE1CGLU A  25      904   1544   1025    405     10   -208       O  
+ATOM    820  OE2AGLU A  25      -3.722  26.488  18.880  0.44 12.21           O  
+ANISOU  820  OE2AGLU A  25     1203   1722   1717    568     15   -144       O  
+ATOM    821  OE2BGLU A  25      -2.064  26.292  17.069  0.38 12.49           O  
+ANISOU  821  OE2BGLU A  25     1531   1643   1573    128     55     97       O  
+ATOM    822  OE2CGLU A  25      -3.116  26.950  18.583  0.18 11.82           O  
+ANISOU  822  OE2CGLU A  25     1209   1679   1604    528     78   -137       O  
+ATOM    823  H  AGLU A  25       0.333  22.448  20.676  0.44  4.72           H  
+ATOM    824  H  BGLU A  25       0.232  22.393  20.604  0.38  4.72           H  
+ATOM    825  H  CGLU A  25       0.511  22.342  20.701  0.18  4.72           H  
+ATOM    826  HA AGLU A  25      -1.115  22.326  18.527  0.44  4.79           H  
+ATOM    827  HA BGLU A  25      -0.971  22.092  18.276  0.38  4.79           H  
+ATOM    828  HA CGLU A  25      -1.022  22.186  18.611  0.18  4.79           H  
+ATOM    829  HB2AGLU A  25      -1.862  23.742  20.203  0.44  6.73           H  
+ATOM    830  HB2BGLU A  25      -1.947  23.209  20.111  0.38  6.73           H  
+ATOM    831  HB2CGLU A  25      -1.735  23.616  20.286  0.18  6.73           H  
+ATOM    832  HB3AGLU A  25      -0.574  24.616  20.117  0.44  6.73           H  
+ATOM    833  HB3BGLU A  25      -0.846  24.311  20.039  0.38  6.73           H  
+ATOM    834  HB3CGLU A  25      -0.464  24.508  20.144  0.18  6.73           H  
+ATOM    835  HG2AGLU A  25      -1.254  25.363  17.963  0.44  8.51           H  
+ATOM    836  HG2BGLU A  25      -2.447  23.969  17.801  0.38  8.51           H  
+ATOM    837  HG2CGLU A  25      -1.301  25.080  17.885  0.18  8.51           H  
+ATOM    838  HG3AGLU A  25      -2.564  24.530  18.104  0.44  8.51           H  
+ATOM    839  HG3BGLU A  25      -3.081  24.694  19.028  0.38  8.51           H  
+ATOM    840  HG3CGLU A  25      -2.653  24.440  18.326  0.18  8.51           H  
+ATOM    841  N   GLN A  26       1.566  24.052  18.218  1.00  3.96           N  
+ANISOU  841  N   GLN A  26      514    609    382      6    221    -21       N  
+ATOM    842  CA  GLN A  26       2.485  24.655  17.263  1.00  3.80           C  
+ANISOU  842  CA  GLN A  26      526    576    343      9    190     13       C  
+ATOM    843  C   GLN A  26       3.062  23.574  16.332  1.00  3.59           C  
+ANISOU  843  C   GLN A  26      502    466    397    -87    186      0       C  
+ATOM    844  O   GLN A  26       3.079  23.715  15.105  1.00  3.78           O  
+ANISOU  844  O   GLN A  26      626    511    300    -67    207     -8       O  
+ATOM    845  CB  GLN A  26       3.623  25.360  17.993  1.00  3.71           C  
+ANISOU  845  CB  GLN A  26      535    473    400    -30    242     15       C  
+ATOM    846  CG  GLN A  26       3.192  26.596  18.762  1.00  3.81           C  
+ANISOU  846  CG  GLN A  26      579    483    387      3    197     16       C  
+ATOM    847  CD  GLN A  26       4.205  26.993  19.825  1.00  4.21           C  
+ANISOU  847  CD  GLN A  26      679    502    417    -78    224    -25       C  
+ATOM    848  OE1 GLN A  26       5.259  26.351  19.977  1.00  4.80           O  
+ANISOU  848  OE1 GLN A  26      630    555    640    -30     66    -21       O  
+ATOM    849  NE2 GLN A  26       3.938  28.067  20.550  1.00  4.88           N  
+ANISOU  849  NE2 GLN A  26      781    584    488      0    172   -118       N  
+ATOM    850  H  AGLN A  26       1.814  24.101  19.040  0.44  3.96           H  
+ATOM    851  H  BGLN A  26       1.779  24.143  19.046  0.38  3.96           H  
+ATOM    852  H  CGLN A  26       1.775  24.186  19.041  0.18  3.96           H  
+ATOM    853  HA  GLN A  26       1.997  25.306  16.736  1.00  3.80           H  
+ATOM    854  HB2 GLN A  26       4.036  24.735  18.609  1.00  3.71           H  
+ATOM    855  HB3 GLN A  26       4.302  25.612  17.348  1.00  3.71           H  
+ATOM    856  HG2 GLN A  26       3.069  27.333  18.144  1.00  3.81           H  
+ATOM    857  HG3 GLN A  26       2.333  26.431  19.181  1.00  3.81           H  
+ATOM    858 HE21 GLN A  26       3.203  28.496  20.428  1.00  4.88           H  
+ATOM    859 HE22 GLN A  26       4.500  28.336  21.143  1.00  4.88           H  
+ATOM    860  N  AARG A  27       3.518  22.475  16.915  0.72  3.45           N  
+ANISOU  860  N  AARG A  27      562    466    283    -35    199     -3       N  
+ATOM    861  N  BARG A  27       3.628  22.537  16.952  0.28  3.51           N  
+ANISOU  861  N  BARG A  27      550    459    327    -85    113    -17       N  
+ATOM    862  CA AARG A  27       4.102  21.404  16.122  0.72  3.05           C  
+ANISOU  862  CA AARG A  27      415    431    314    -13    209     33       C  
+ATOM    863  CA BARG A  27       4.285  21.477  16.202  0.28  4.02           C  
+ANISOU  863  CA BARG A  27      584    550    394   -195     23    -70       C  
+ATOM    864  C  AARG A  27       3.099  20.823  15.127  0.72  3.21           C  
+ANISOU  864  C  AARG A  27      449    461    310     -6    213    -32       C  
+ATOM    865  C  BARG A  27       3.289  20.903  15.191  0.28  3.82           C  
+ANISOU  865  C  BARG A  27      574    467    411    -75    112     89       C  
+ATOM    866  O  AARG A  27       3.394  20.645  13.942  0.72  3.60           O  
+ANISOU  866  O  AARG A  27      522    521    324     17    224    -51       O  
+ATOM    867  O  BARG A  27       3.602  20.730  14.012  0.28  3.93           O  
+ANISOU  867  O  BARG A  27      597    511    384    -36     12    -19       O  
+ATOM    868  CB AARG A  27       4.617  20.329  17.087  0.72  3.03           C  
+ANISOU  868  CB AARG A  27      462    411    278    -36    200    -10       C  
+ATOM    869  CB BARG A  27       4.772  20.356  17.107  0.28  5.58           C  
+ANISOU  869  CB BARG A  27      719    723    677   -203    -77    -17       C  
+ATOM    870  CG AARG A  27       5.487  19.270  16.394  0.72  4.08           C  
+ANISOU  870  CG AARG A  27      570    538    442     45    198    -71       C  
+ATOM    871  CG BARG A  27       5.592  19.337  16.344  0.28  5.80           C  
+ANISOU  871  CG BARG A  27      735    771    696    -85   -106     24       C  
+ATOM    872  CD AARG A  27       5.776  18.087  17.283  0.72  5.15           C  
+ANISOU  872  CD AARG A  27      713    463    781     67    131    -20       C  
+ATOM    873  CD BARG A  27       5.812  18.083  17.144  0.28  5.66           C  
+ANISOU  873  CD BARG A  27      723    684    742    -89     24     54       C  
+ATOM    874  NE AARG A  27       6.198  18.394  18.655  0.72  5.63           N  
+ANISOU  874  NE AARG A  27      774    750    617     41     97    267       N  
+ATOM    875  NE BARG A  27       6.047  18.393  18.550  0.28  5.95           N  
+ANISOU  875  NE BARG A  27      762    776    724   -116    136     43       N  
+ATOM    876  CZ AARG A  27       7.354  18.967  18.996  0.72  5.13           C  
+ANISOU  876  CZ AARG A  27      782    653    515     77    133    165       C  
+ATOM    877  CZ BARG A  27       7.164  18.938  19.022  0.28  6.03           C  
+ANISOU  877  CZ BARG A  27      840    796    656    -48    198    -83       C  
+ATOM    878  NH1AARG A  27       8.269  19.320  18.101  0.72  5.20           N  
+ANISOU  878  NH1AARG A  27      744    804    427    -94     53     -8       N  
+ATOM    879  NH1BARG A  27       8.185  19.226  18.222  0.28  4.53           N  
+ANISOU  879  NH1BARG A  27      655    592    475     -9    181   -248       N  
+ATOM    880  NH2AARG A  27       7.597  19.202  20.281  0.72  7.62           N  
+ANISOU  880  NH2AARG A  27     1246   1108    540    -47     91    124       N  
+ATOM    881  NH2BARG A  27       7.265  19.194  20.315  0.28  7.97           N  
+ANISOU  881  NH2BARG A  27     1118   1081    829    -99    242    -47       N  
+ATOM    882  H  AARG A  27       3.499  22.330  17.762  0.72  3.51           H  
+ATOM    883  H  BARG A  27       3.640  22.432  17.806  0.28  3.51           H  
+ATOM    884  HA AARG A  27       4.835  21.754  15.591  0.72  4.02           H  
+ATOM    885  HA BARG A  27       5.059  21.857  15.757  0.28  4.02           H  
+ATOM    886  HB2AARG A  27       5.132  20.753  17.791  0.72  5.58           H  
+ATOM    887  HB2BARG A  27       5.306  20.729  17.826  0.28  5.58           H  
+ATOM    888  HB3AARG A  27       3.861  19.893  17.511  0.72  5.58           H  
+ATOM    889  HB3BARG A  27       4.011  19.917  17.518  0.28  5.58           H  
+ATOM    890  HG2AARG A  27       5.040  18.964  15.589  0.72  5.80           H  
+ATOM    891  HG2BARG A  27       5.142  19.116  15.514  0.28  5.80           H  
+ATOM    892  HG3AARG A  27       6.324  19.674  16.117  0.72  5.80           H  
+ATOM    893  HG3BARG A  27       6.449  19.724  16.107  0.28  5.80           H  
+ATOM    894  HD2AARG A  27       4.979  17.536  17.325  0.72  5.66           H  
+ATOM    895  HD2BARG A  27       5.038  17.504  17.062  0.28  5.66           H  
+ATOM    896  HD3AARG A  27       6.468  17.553  16.864  0.72  5.66           H  
+ATOM    897  HD3BARG A  27       6.570  17.596  16.786  0.28  5.66           H  
+ATOM    898  HE AARG A  27       5.656  18.188  19.291  0.72  5.95           H  
+ATOM    899  HE BARG A  27       5.421  18.211  19.111  0.28  5.95           H  
+ATOM    900 HH11AARG A  27       8.128  19.181  17.264  0.72  4.53           H  
+ATOM    901 HH11BARG A  27       8.132  19.060  17.380  0.28  4.53           H  
+ATOM    902 HH12AARG A  27       9.003  19.687  18.358  0.72  4.53           H  
+ATOM    903 HH12BARG A  27       8.899  19.578  18.546  0.28  4.53           H  
+ATOM    904 HH21AARG A  27       7.014  18.986  20.875  0.72  7.97           H  
+ATOM    905 HH21BARG A  27       6.612  19.008  20.842  0.28  7.97           H  
+ATOM    906 HH22AARG A  27       8.337  19.571  20.518  0.72  7.97           H  
+ATOM    907 HH22BARG A  27       7.984  19.546  20.629  0.28  7.97           H  
+ATOM    908  N  AASN A  28       1.903  20.540  15.617  0.72  3.54           N  
+ANISOU  908  N  AASN A  28      474    541    331   -106    199    -33       N  
+ATOM    909  N  BASN A  28       2.077  20.614  15.654  0.28  4.53           N  
+ANISOU  909  N  BASN A  28      673    654    395   -107     91    -36       N  
+ATOM    910  CA AASN A  28       0.879  19.946  14.782  0.72  3.88           C  
+ANISOU  910  CA AASN A  28      504    551    419    -78    163    -38       C  
+ATOM    911  CA BASN A  28       1.071  20.007  14.783  0.28  4.90           C  
+ANISOU  911  CA BASN A  28      665    669    527   -100    180    -34       C  
+ATOM    912  C  AASN A  28       0.557  20.852  13.600  0.72  3.91           C  
+ANISOU  912  C  AASN A  28      516    581    389    -54    203    -63       C  
+ATOM    913  C  BASN A  28       0.707  20.890  13.607  0.28  4.28           C  
+ANISOU  913  C  BASN A  28      487    683    454   -108     53    -87       C  
+ATOM    914  O  AASN A  28       0.301  20.372  12.507  0.72  4.64           O  
+ANISOU  914  O  AASN A  28      618    713    434    -49     81    -81       O  
+ATOM    915  O  BASN A  28       0.515  20.397  12.504  0.28  4.53           O  
+ANISOU  915  O  BASN A  28      556    666    499   -135    136    -20       O  
+ATOM    916  CB AASN A  28      -0.381  19.680  15.594  0.72  5.06           C  
+ANISOU  916  CB AASN A  28      541    813    570   -277    214     -7       C  
+ATOM    917  CB BASN A  28      -0.219  19.655  15.525  0.28  7.66           C  
+ANISOU  917  CB BASN A  28      967   1046    898   -197     29    -17       C  
+ATOM    918  CG AASN A  28      -0.198  18.555  16.617  0.72  6.44           C  
+ANISOU  918  CG AASN A  28      972    865    611   -356    290     60       C  
+ATOM    919  CG BASN A  28      -1.287  19.104  14.584  0.28 10.19           C  
+ANISOU  919  CG BASN A  28     1269   1362   1239   -241     13     81       C  
+ATOM    920  OD1AASN A  28       0.740  17.759  16.528  0.72  7.36           O  
+ANISOU  920  OD1AASN A  28     1271    868    658   -143    322    141       O  
+ATOM    921  OD1BASN A  28      -1.194  17.963  14.131  0.28 11.83           O  
+ANISOU  921  OD1BASN A  28     1484   1481   1531   -321     59     13       O  
+ATOM    922  ND2AASN A  28      -1.090  18.504  17.592  0.72  7.81           N  
+ANISOU  922  ND2AASN A  28     1034   1038    895   -322    441    128       N  
+ATOM    923  ND2BASN A  28      -2.288  19.923  14.265  0.28 12.33           N  
+ANISOU  923  ND2BASN A  28     1538   1659   1489   -175   -147    157       N  
+ATOM    924  H  AASN A  28       1.665  20.685  16.431  0.72  4.53           H  
+ATOM    925  H  BASN A  28       1.817  20.759  16.461  0.28  4.53           H  
+ATOM    926  HA AASN A  28       1.217  19.102  14.442  0.72  4.90           H  
+ATOM    927  HA BASN A  28       1.490  19.194  14.461  0.28  4.90           H  
+ATOM    928  HB2AASN A  28      -0.641  20.492  16.055  0.72  7.66           H  
+ATOM    929  HB2BASN A  28      -0.027  19.000  16.214  0.28  7.66           H  
+ATOM    930  HB3AASN A  28      -1.106  19.450  14.992  0.72  7.66           H  
+ATOM    931  HB3BASN A  28      -0.560  20.445  15.973  0.28  7.66           H  
+ATOM    932 HD21AASN A  28      -1.030  17.897  18.199  0.72 12.33           H  
+ATOM    933 HD21BASN A  28      -2.902  19.661  13.723  0.28 12.33           H  
+ATOM    934 HD22AASN A  28      -1.730  19.078  17.619  0.72 12.33           H  
+ATOM    935 HD22BASN A  28      -2.320  20.714  14.601  0.28 12.33           H  
+ATOM    936  N  AGLY A  29       0.541  22.164  13.818  0.04  4.01           N  
+ANISOU  936  N  AGLY A  29      543    611    369    -28    156    -14       N  
+ATOM    937  N  BGLY A  29       0.557  22.186  13.837  0.96  4.26           N  
+ANISOU  937  N  BGLY A  29      545    622    453    -29    166   -119       N  
+ATOM    938  CA  GLY A  29       0.260  23.100  12.740  1.00  4.57           C  
+ANISOU  938  CA  GLY A  29      537    653    546     26    128    -83       C  
+ATOM    939  C   GLY A  29       1.320  23.059  11.653  1.00  4.03           C  
+ANISOU  939  C   GLY A  29      603    478    451     30     77      7       C  
+ATOM    940  O   GLY A  29       1.008  23.070  10.465  1.00  4.49           O  
+ANISOU  940  O   GLY A  29      612    613    483    -43     64     15       O  
+ATOM    941  H  AGLY A  29       0.690  22.530  14.582  0.04  4.26           H  
+ATOM    942  H  BGLY A  29       0.622  22.555  14.611  0.96  4.26           H  
+ATOM    943  HA2AGLY A  29      -0.606  22.895  12.353  0.04  4.57           H  
+ATOM    944  HA2BGLY A  29      -0.602  22.873  12.357  0.96  4.57           H  
+ATOM    945  HA3AGLY A  29       0.204  23.999  13.101  0.04  4.57           H  
+ATOM    946  HA3BGLY A  29       0.188  24.004  13.085  0.96  4.57           H  
+ATOM    947  N   PHE A  30       2.604  23.021  12.055  1.00  3.55           N  
+ANISOU  947  N   PHE A  30      530    439    379    -25    101     16       N  
+ATOM    948  CA  PHE A  30       3.654  22.963  11.076  1.00  3.70           C  
+ANISOU  948  CA  PHE A  30      555    463    389      7    123     35       C  
+ATOM    949  C   PHE A  30       3.627  21.641  10.299  1.00  3.75           C  
+ANISOU  949  C   PHE A  30      535    527    361    -14    132     -1       C  
+ATOM    950  O   PHE A  30       3.791  21.625   9.065  1.00  4.52           O  
+ANISOU  950  O   PHE A  30      716    674    326     -5    145      0       O  
+ATOM    951  CB  PHE A  30       5.026  23.160  11.736  1.00  3.85           C  
+ANISOU  951  CB  PHE A  30      510    545    408      0    210     48       C  
+ATOM    952  CG  PHE A  30       5.262  24.531  12.330  1.00  3.95           C  
+ANISOU  952  CG  PHE A  30      426    618    458    -65    232     22       C  
+ATOM    953  CD1 PHE A  30       5.134  25.683  11.585  1.00  4.46           C  
+ANISOU  953  CD1 PHE A  30      633    598    465    -52    191     43       C  
+ATOM    954  CD2 PHE A  30       5.706  24.646  13.627  1.00  4.16           C  
+ANISOU  954  CD2 PHE A  30      506    620    453    -69    207     50       C  
+ATOM    955  CE1 PHE A  30       5.404  26.943  12.143  1.00  4.75           C  
+ANISOU  955  CE1 PHE A  30      662    534    607   -121    236     28       C  
+ATOM    956  CE2 PHE A  30       5.981  25.887  14.184  1.00  4.81           C  
+ANISOU  956  CE2 PHE A  30      630    734    464   -202    153    -12       C  
+ATOM    957  CZ  PHE A  30       5.830  27.040  13.436  1.00  5.09           C  
+ANISOU  957  CZ  PHE A  30      615    659    660   -151    220    -67       C  
+ATOM    958  H   PHE A  30       2.864  23.028  12.875  1.00  3.55           H  
+ATOM    959  HA  PHE A  30       3.503  23.685  10.446  1.00  3.70           H  
+ATOM    960  HB2 PHE A  30       5.131  22.497  12.436  1.00  3.85           H  
+ATOM    961  HB3 PHE A  30       5.715  22.986  11.076  1.00  3.85           H  
+ATOM    962  HD1 PHE A  30       4.864  25.625  10.697  1.00  4.46           H  
+ATOM    963  HD2 PHE A  30       5.824  23.879  14.139  1.00  4.16           H  
+ATOM    964  HE1 PHE A  30       5.293  27.712  11.631  1.00  4.75           H  
+ATOM    965  HE2 PHE A  30       6.269  25.943  15.067  1.00  4.81           H  
+ATOM    966  HZ  PHE A  30       6.016  27.871  13.809  1.00  5.09           H  
+ATOM    967  N   ILE A  31       3.431  20.537  11.002  1.00  3.68           N  
+ANISOU  967  N   ILE A  31      592    507    299     13    148     -8       N  
+ATOM    968  CA  ILE A  31       3.325  19.229  10.347  1.00  4.18           C  
+ANISOU  968  CA  ILE A  31      657    516    416     45    221    -45       C  
+ATOM    969  C   ILE A  31       2.164  19.208   9.374  1.00  4.26           C  
+ANISOU  969  C   ILE A  31      697    553    368     -4    155    -58       C  
+ATOM    970  O   ILE A  31       2.290  18.677   8.264  1.00  5.48           O  
+ANISOU  970  O   ILE A  31      903    735    444     27     96   -136       O  
+ATOM    971  CB  ILE A  31       3.270  18.092  11.390  1.00  4.29           C  
+ANISOU  971  CB  ILE A  31      585    510    534    -16    199     26       C  
+ATOM    972  CG1 ILE A  31       4.604  17.971  12.159  1.00  4.49           C  
+ANISOU  972  CG1 ILE A  31      756    491    459     48    123     45       C  
+ATOM    973  CG2 ILE A  31       2.879  16.770  10.737  1.00  5.52           C  
+ANISOU  973  CG2 ILE A  31      787    596    713    -59     96    -12       C  
+ATOM    974  CD1 ILE A  31       5.809  17.556  11.355  1.00  5.29           C  
+ANISOU  974  CD1 ILE A  31      728    658    626     60    113    -25       C  
+ATOM    975  H   ILE A  31       3.356  20.516  11.858  1.00  3.68           H  
+ATOM    976  HA  ILE A  31       4.125  19.074   9.821  1.00  4.18           H  
+ATOM    977  HB  ILE A  31       2.583  18.315  12.037  1.00  4.29           H  
+ATOM    978 HG12 ILE A  31       4.795  18.828  12.572  1.00  4.49           H  
+ATOM    979 HG13 ILE A  31       4.483  17.330  12.877  1.00  4.49           H  
+ATOM    980 HG21 ILE A  31       2.851  16.072  11.410  1.00  5.52           H  
+ATOM    981 HG22 ILE A  31       2.005  16.858  10.326  1.00  5.52           H  
+ATOM    982 HG23 ILE A  31       3.532  16.538  10.059  1.00  5.52           H  
+ATOM    983 HD11 ILE A  31       6.586  17.512  11.935  1.00  5.29           H  
+ATOM    984 HD12 ILE A  31       5.651  16.684  10.961  1.00  5.29           H  
+ATOM    985 HD13 ILE A  31       5.967  18.204  10.651  1.00  5.29           H  
+ATOM    986  N   GLN A  32       1.018  19.759   9.768  1.00  4.69           N  
+ANISOU  986  N   GLN A  32      673    684    423    -53    100    -46       N  
+ATOM    987  CA  GLN A  32      -0.142  19.794   8.878  1.00  5.23           C  
+ANISOU  987  CA  GLN A  32      693    769    525     -5     15    -99       C  
+ATOM    988  C   GLN A  32       0.181  20.582   7.609  1.00  5.43           C  
+ANISOU  988  C   GLN A  32      668    973    423     58     24    -61       C  
+ATOM    989  O   GLN A  32      -0.250  20.218   6.529  1.00  6.06           O  
+ANISOU  989  O   GLN A  32      731   1060    510    -16    -16   -107       O  
+ATOM    990  CB  GLN A  32      -1.355  20.388   9.605  1.00  6.08           C  
+ANISOU  990  CB  GLN A  32      765    961    584     30    102    -29       C  
+ATOM    991  CG  GLN A  32      -2.611  20.437   8.739  1.00  7.38           C  
+ANISOU  991  CG  GLN A  32      772   1222    810      5    130    -52       C  
+ATOM    992  CD  GLN A  32      -3.156  19.075   8.461  1.00  9.54           C  
+ANISOU  992  CD  GLN A  32      785   1616   1225   -247      1     54       C  
+ATOM    993  OE1 GLN A  32      -3.341  18.290   9.390  1.00 13.70           O  
+ANISOU  993  OE1 GLN A  32     1519   1944   1743   -680     64    317       O  
+ATOM    994  NE2 GLN A  32      -3.470  18.789   7.224  1.00 11.04           N  
+ANISOU  994  NE2 GLN A  32     1292   1503   1398   -278     26   -167       N  
+ATOM    995  H   GLN A  32       0.891  20.116  10.540  1.00  4.69           H  
+ATOM    996  HA  GLN A  32      -0.363  18.886   8.618  1.00  5.23           H  
+ATOM    997  HB2 GLN A  32      -1.538  19.863  10.400  1.00  6.08           H  
+ATOM    998  HB3 GLN A  32      -1.139  21.286   9.902  1.00  6.08           H  
+ATOM    999  HG2 GLN A  32      -3.288  20.970   9.184  1.00  7.38           H  
+ATOM   1000  HG3 GLN A  32      -2.407  20.880   7.900  1.00  7.38           H  
+ATOM   1001 HE21 GLN A  32      -3.326  19.363   6.600  1.00 11.04           H  
+ATOM   1002 HE22 GLN A  32      -3.820  18.027   7.035  1.00 11.04           H  
+ATOM   1003  N   SER A  33       0.921  21.682   7.733  1.00  5.26           N  
+ANISOU 1003  N   SER A  33      752    825    423    -53    -18     -3       N  
+ATOM   1004  CA  SER A  33       1.305  22.446   6.550  1.00  6.16           C  
+ANISOU 1004  CA  SER A  33      824   1029    487    -60     16    157       C  
+ATOM   1005  C  ASER A  33       2.126  21.627   5.605  0.34  7.23           C  
+ANISOU 1005  C  ASER A  33      865   1299    585    -60    143     52       C  
+ATOM   1006  C  BSER A  33       2.115  21.573   5.561  0.66  6.58           C  
+ANISOU 1006  C  BSER A  33      894   1265    341    -43    -10     75       C  
+ATOM   1007  O  ASER A  33       1.882  21.640   4.407  0.34  7.07           O  
+ANISOU 1007  O  ASER A  33      957   1362    366     60     22    -29       O  
+ATOM   1008  O  BSER A  33       1.916  21.677   4.347  0.66  7.19           O  
+ANISOU 1008  O  BSER A  33      915   1390    428     14     19    132       O  
+ATOM   1009  CB  SER A  33       2.096  23.687   6.935  1.00  6.80           C  
+ANISOU 1009  CB  SER A  33     1010    972    602    -75     36    105       C  
+ATOM   1010  OG  SER A  33       1.278  24.602   7.640  1.00  9.44           O  
+ANISOU 1010  OG  SER A  33     1536   1089    963   -292     10     86       O  
+ATOM   1011  H   SER A  33       1.207  21.998   8.480  1.00  5.26           H  
+ATOM   1012  HA ASER A  33       0.482  22.707   6.109  0.34  6.16           H  
+ATOM   1013  HA BSER A  33       0.490  22.730   6.107  0.66  6.16           H  
+ATOM   1014  HB2 SER A  33       2.855  23.435   7.484  1.00  6.80           H  
+ATOM   1015  HB3 SER A  33       2.451  24.111   6.138  1.00  6.80           H  
+ATOM   1016  HG  SER A  33       1.123  25.270   7.155  1.00  9.44           H  
+ATOM   1017  N  ALEU A  34       3.109  20.913   6.128  0.48  6.51           N  
+ANISOU 1017  N  ALEU A  34      762   1348    366    110    -15    -12       N  
+ATOM   1018  N  BLEU A  34       3.004  20.706   6.066  0.52  6.64           N  
+ANISOU 1018  N  BLEU A  34      875   1213    437    199    153    185       N  
+ATOM   1019  CA ALEU A  34       3.839  19.977   5.271  0.48  7.91           C  
+ANISOU 1019  CA ALEU A  34     1049   1391    567    235    191     90       C  
+ATOM   1020  CA BLEU A  34       3.851  19.811   5.225  0.52  7.76           C  
+ANISOU 1020  CA BLEU A  34     1031   1286    630    346    173    187       C  
+ATOM   1021  C  ALEU A  34       2.907  18.985   4.586  0.48  8.35           C  
+ANISOU 1021  C  ALEU A  34     1123   1548    503    278    145   -167       C  
+ATOM   1022  C  BLEU A  34       3.054  18.658   4.650  0.52  7.61           C  
+ANISOU 1022  C  BLEU A  34      903   1503    486    530    -36   -145       C  
+ATOM   1023  O  ALEU A  34       3.073  18.750   3.411  0.48  9.16           O  
+ANISOU 1023  O  ALEU A  34     1235   1682    562    589    -15   -167       O  
+ATOM   1024  O  BLEU A  34       3.266  18.209   3.543  0.52  8.49           O  
+ANISOU 1024  O  BLEU A  34     1051   1617    558    603    -36   -189       O  
+ATOM   1025  CB ALEU A  34       4.926  19.209   6.006  0.48  7.35           C  
+ANISOU 1025  CB ALEU A  34      967   1103    723     68    268    -59       C  
+ATOM   1026  CB BLEU A  34       5.054  19.232   5.982  0.52  9.18           C  
+ANISOU 1026  CB BLEU A  34     1113   1384    989    142     17    227       C  
+ATOM   1027  CG ALEU A  34       5.908  20.126   6.708  0.48  7.82           C  
+ANISOU 1027  CG ALEU A  34     1018   1053    900    -55    536   -222       C  
+ATOM   1028  CG BLEU A  34       6.396  19.958   5.827  0.52 11.06           C  
+ANISOU 1028  CG BLEU A  34     1292   1570   1340    141    -35    267       C  
+ATOM   1029  CD1ALEU A  34       6.956  19.305   7.440  0.48  8.94           C  
+ANISOU 1029  CD1ALEU A  34     1068   1191   1138    -39    -12   -277       C  
+ATOM   1030  CD1BLEU A  34       6.286  21.311   6.509  0.52 11.36           C  
+ANISOU 1030  CD1BLEU A  34     1383   1505   1428    102     45    154       C  
+ATOM   1031  CD2ALEU A  34       6.570  21.055   5.699  0.48  9.45           C  
+ANISOU 1031  CD2ALEU A  34     1241   1190   1160   -191    635   -351       C  
+ATOM   1032  CD2BLEU A  34       7.561  19.189   6.435  0.52 13.87           C  
+ANISOU 1032  CD2BLEU A  34     1623   1887   1761     75   -302      5       C  
+ATOM   1033  H  ALEU A  34       3.367  20.947   6.948  0.48  6.64           H  
+ATOM   1034  H  BLEU A  34       3.140  20.613   6.910  0.52  6.64           H  
+ATOM   1035  HA ALEU A  34       4.266  20.535   4.602  0.48  7.76           H  
+ATOM   1036  HA BLEU A  34       4.178  20.379   4.510  0.52  7.76           H  
+ATOM   1037  HB2ALEU A  34       4.517  18.618   6.657  0.48  9.18           H  
+ATOM   1038  HB2BLEU A  34       4.832  19.209   6.926  0.52  9.18           H  
+ATOM   1039  HB3ALEU A  34       5.405  18.648   5.376  0.48  9.18           H  
+ATOM   1040  HB3BLEU A  34       5.175  18.313   5.696  0.52  9.18           H  
+ATOM   1041  HG ALEU A  34       5.428  20.665   7.356  0.48 11.06           H  
+ATOM   1042  HG BLEU A  34       6.578  20.046   4.878  0.52 11.06           H  
+ATOM   1043 HD11ALEU A  34       7.580  19.899   7.886  0.48 11.36           H  
+ATOM   1044 HD11BLEU A  34       7.127  21.787   6.422  0.52 11.36           H  
+ATOM   1045 HD12ALEU A  34       6.523  18.739   8.098  0.48 11.36           H  
+ATOM   1046 HD12BLEU A  34       5.578  21.827   6.092  0.52 11.36           H  
+ATOM   1047 HD13ALEU A  34       7.436  18.752   6.804  0.48 11.36           H  
+ATOM   1048 HD13BLEU A  34       6.083  21.184   7.449  0.52 11.36           H  
+ATOM   1049 HD21ALEU A  34       7.196  21.637   6.157  0.48 13.87           H  
+ATOM   1050 HD21BLEU A  34       8.381  19.691   6.309  0.52 13.87           H  
+ATOM   1051 HD22ALEU A  34       7.044  20.528   5.037  0.48 13.87           H  
+ATOM   1052 HD22BLEU A  34       7.404  19.060   7.383  0.52 13.87           H  
+ATOM   1053 HD23ALEU A  34       5.892  21.592   5.260  0.48 13.87           H  
+ATOM   1054 HD23BLEU A  34       7.641  18.326   6.000  0.52 13.87           H  
+ATOM   1055  N  ALYS A  35       1.990  18.366   5.351  0.48  9.76           N  
+ANISOU 1055  N  ALYS A  35     1444   1621    644    186    -10   -440       N  
+ATOM   1056  N  BLYS A  35       2.110  18.172   5.426  0.52  8.69           N  
+ANISOU 1056  N  BLYS A  35     1286   1423    592    671    -78   -210       N  
+ATOM   1057  CA ALYS A  35       1.035  17.372   4.829  0.48  9.76           C  
+ANISOU 1057  CA ALYS A  35     1426   1427    854    163     33   -465       C  
+ATOM   1058  CA BLYS A  35       1.221  17.184   4.892  0.52  8.47           C  
+ANISOU 1058  CA BLYS A  35     1381   1123    713    513     43   -251       C  
+ATOM   1059  C  ALYS A  35       0.216  17.952   3.685  0.48  8.76           C  
+ANISOU 1059  C  ALYS A  35     1185   1498    644    145   -171   -428       C  
+ATOM   1060  C  BLYS A  35       0.478  17.790   3.703  0.52  8.44           C  
+ANISOU 1060  C  BLYS A  35     1378   1076    752    415     93   -133       C  
+ATOM   1061  O  ALYS A  35      -0.081  17.276   2.710  0.48  9.46           O  
+ANISOU 1061  O  ALYS A  35     1137   1674    782    198   -230   -537       O  
+ATOM   1062  O  BLYS A  35       0.447  17.201   2.627  0.52  9.30           O  
+ANISOU 1062  O  BLYS A  35     1548   1203    782    340     94   -238       O  
+ATOM   1063  CB ALYS A  35       0.094  16.840   5.938  0.48 11.44           C  
+ANISOU 1063  CB ALYS A  35     1635   1511   1201     36     41   -545       C  
+ATOM   1064  CB BLYS A  35       0.252  16.731   5.965  0.52 11.51           C  
+ANISOU 1064  CB BLYS A  35     1751   1492   1131    421     27   -444       C  
+ATOM   1065  CG ALYS A  35      -1.055  15.959   5.418  0.48 13.57           C  
+ANISOU 1065  CG ALYS A  35     1795   1760   1601    -59     -2   -405       C  
+ATOM   1066  CG BLYS A  35      -0.573  15.591   5.497  0.52 13.39           C  
+ANISOU 1066  CG BLYS A  35     1869   1730   1491    270     70   -479       C  
+ATOM   1067  CD ALYS A  35      -2.059  15.551   6.495  0.48 15.03           C  
+ANISOU 1067  CD ALYS A  35     1935   1903   1874    -62    -14   -181       C  
+ATOM   1068  CD BLYS A  35      -1.632  15.228   6.491  0.52 14.87           C  
+ANISOU 1068  CD BLYS A  35     1983   1858   1810     73    309   -344       C  
+ATOM   1069  CE ALYS A  35      -3.032  14.505   5.946  0.48 15.50           C  
+ANISOU 1069  CE ALYS A  35     1964   1936   1990    -90     89   -158       C  
+ATOM   1070  CE BLYS A  35      -2.501  14.081   5.984  0.52 14.68           C  
+ANISOU 1070  CE BLYS A  35     1915   1789   1873     35    427   -325       C  
+ATOM   1071  NZ ALYS A  35      -4.014  14.051   6.956  0.48 16.41           N  
+ANISOU 1071  NZ ALYS A  35     2081   2060   2094   -170     84   -159       N  
+ATOM   1072  NZ BLYS A  35      -3.168  14.396   4.689  0.52 14.52           N  
+ANISOU 1072  NZ BLYS A  35     1902   1764   1850     -7    611   -346       N  
+ATOM   1073  H  ALYS A  35       1.906  18.514   6.194  0.48  8.69           H  
+ATOM   1074  H  BLYS A  35       1.972  18.397   6.245  0.52  8.69           H  
+ATOM   1075  HA ALYS A  35       1.557  16.626   4.495  0.48  8.47           H  
+ATOM   1076  HA BLYS A  35       1.719  16.407   4.594  0.52  8.47           H  
+ATOM   1077  HB2ALYS A  35       0.617  16.329   6.575  0.48 11.51           H  
+ATOM   1078  HB2BLYS A  35       0.744  16.472   6.760  0.52 11.51           H  
+ATOM   1079  HB3ALYS A  35      -0.282  17.594   6.419  0.48 11.51           H  
+ATOM   1080  HB3BLYS A  35      -0.325  17.469   6.216  0.52 11.51           H  
+ATOM   1081  HG2ALYS A  35      -1.524  16.436   4.715  0.48 13.39           H  
+ATOM   1082  HG2BLYS A  35      -0.988  15.818   4.650  0.52 13.39           H  
+ATOM   1083  HG3ALYS A  35      -0.681  15.159   5.017  0.48 13.39           H  
+ATOM   1084  HG3BLYS A  35      -0.003  14.823   5.337  0.52 13.39           H  
+ATOM   1085  HD2ALYS A  35      -1.589  15.193   7.264  0.48 14.87           H  
+ATOM   1086  HD2BLYS A  35      -1.217  14.975   7.331  0.52 14.87           H  
+ATOM   1087  HD3ALYS A  35      -2.550  16.330   6.800  0.48 14.87           H  
+ATOM   1088  HD3BLYS A  35      -2.188  16.002   6.671  0.52 14.87           H  
+ATOM   1089  HE2ALYS A  35      -3.505  14.877   5.185  0.48 14.68           H  
+ATOM   1090  HE2BLYS A  35      -1.953  13.288   5.877  0.52 14.68           H  
+ATOM   1091  HE3ALYS A  35      -2.530  13.741   5.622  0.48 14.68           H  
+ATOM   1092  HE3BLYS A  35      -3.176  13.872   6.649  0.52 14.68           H  
+ATOM   1093  HZ1ALYS A  35      -4.356  13.268   6.707  0.48 14.52           H  
+ATOM   1094  HZ1BLYS A  35      -4.009  14.107   4.710  0.52 14.52           H  
+ATOM   1095  HZ2ALYS A  35      -3.610  13.961   7.744  0.48 14.52           H  
+ATOM   1096  HZ2BLYS A  35      -3.161  15.276   4.557  0.52 14.52           H  
+ATOM   1097  HZ3ALYS A  35      -4.668  14.651   7.025  0.48 14.52           H  
+ATOM   1098  HZ3BLYS A  35      -2.733  13.993   4.025  0.52 14.52           H  
+ATOM   1099  N  AASP A  36      -0.143  19.215   3.826  0.48  7.83           N  
+ANISOU 1099  N  AASP A  36     1003   1474    498   -118   -147   -215       N  
+ATOM   1100  N  BASP A  36      -0.070  18.982   3.905  0.52  7.11           N  
+ANISOU 1100  N  BASP A  36     1057    993    652    370     61    126       N  
+ATOM   1101  CA AASP A  36      -0.955  19.842   2.814  0.48  8.06           C  
+ANISOU 1101  CA AASP A  36      982   1489    592   -126   -314   -105       C  
+ATOM   1102  CA BASP A  36      -0.877  19.661   2.892  0.52  7.37           C  
+ANISOU 1102  CA BASP A  36      929   1217    653    179    -10     43       C  
+ATOM   1103  C  AASP A  36      -0.157  20.165   1.572  0.48  8.13           C  
+ANISOU 1103  C  AASP A  36      934   1558    596   -204    -54   -182       C  
+ATOM   1104  C  BASP A  36      -0.075  19.860   1.595  0.52  6.75           C  
+ANISOU 1104  C  BASP A  36      910   1142    512    162    -45    -96       C  
+ATOM   1105  O  AASP A  36      -0.699  20.152   0.484  0.48  8.36           O  
+ANISOU 1105  O  AASP A  36      979   1691    505   -264    -97   -159       O  
+ATOM   1106  O  BASP A  36      -0.555  19.539   0.505  0.52  7.09           O  
+ANISOU 1106  O  BASP A  36      953   1224    518     57    -49    -60       O  
+ATOM   1107  CB AASP A  36      -1.617  21.074   3.392  0.48 12.00           C  
+ANISOU 1107  CB AASP A  36     1367   1970   1224     68   -405    -32       C  
+ATOM   1108  CB BASP A  36      -1.358  21.051   3.398  0.52  8.17           C  
+ANISOU 1108  CB BASP A  36      888   1497    721    403   -149    120       C  
+ATOM   1109  CG AASP A  36      -2.903  20.735   4.102  0.48 12.72           C  
+ANISOU 1109  CG AASP A  36     1167   2130   1537    160     10    -51       C  
+ATOM   1110  CG BASP A  36      -2.452  20.981   4.467  0.52  9.29           C  
+ANISOU 1110  CG BASP A  36      813   1872    846    420     -4     56       C  
+ATOM   1111  OD1AASP A  36      -3.707  19.941   3.578  0.48 14.91           O  
+ANISOU 1111  OD1AASP A  36     1421   2301   1944     84    307   -269       O  
+ATOM   1112  OD1BASP A  36      -3.007  19.890   4.698  0.52 10.17           O  
+ANISOU 1112  OD1BASP A  36      754   2130    980     64    101    218       O  
+ATOM   1113  OD2AASP A  36      -3.130  21.249   5.190  0.48 12.04           O  
+ANISOU 1113  OD2AASP A  36      904   2259   1411    199    242    117       O  
+ATOM   1114  OD2BASP A  36      -2.755  22.043   5.062  0.52 11.89           O  
+ANISOU 1114  OD2BASP A  36     1156   2110   1254    469    314    -20       O  
+ATOM   1115  H  AASP A  36       0.071  19.717   4.491  0.48  7.11           H  
+ATOM   1116  H  BASP A  36       0.015  19.425   4.637  0.52  7.11           H  
+ATOM   1117  HA AASP A  36      -1.644  19.218   2.538  0.48  7.37           H  
+ATOM   1118  HA BASP A  36      -1.647  19.098   2.716  0.52  7.37           H  
+ATOM   1119  HB2AASP A  36      -1.010  21.507   4.012  0.48  8.17           H  
+ATOM   1120  HB2BASP A  36      -0.598  21.535   3.758  0.52  8.17           H  
+ATOM   1121  HB3AASP A  36      -1.797  21.709   2.681  0.48  8.17           H  
+ATOM   1122  HB3BASP A  36      -1.689  21.563   2.643  0.52  8.17           H  
+ATOM   1123  N  AASP A  37       1.127  20.444   1.728  0.97  6.92           N  
+ANISOU 1123  N  AASP A  37      803   1323    503     51     41   -206       N  
+ATOM   1124  N  BASP A  37       1.114  20.445   1.721  0.03  7.85           N  
+ANISOU 1124  N  BASP A  37     1023   1221    740     93    154   -172       N  
+ATOM   1125  CA  ASP A  37       1.965  20.739   0.570  1.00  6.98           C  
+ANISOU 1125  CA  ASP A  37      813   1343    494     48     -7   -194       C  
+ATOM   1126  C   ASP A  37       3.437  20.605   0.963  1.00  7.32           C  
+ANISOU 1126  C   ASP A  37      859   1340    583     49    157   -227       C  
+ATOM   1127  O   ASP A  37       4.009  21.532   1.489  1.00  6.95           O  
+ANISOU 1127  O   ASP A  37      796   1222    623    122      3   -247       O  
+ATOM   1128  CB  ASP A  37       1.706  22.138   0.064  1.00  7.77           C  
+ANISOU 1128  CB  ASP A  37      721   1538    694    134    -59   -235       C  
+ATOM   1129  CG  ASP A  37       2.501  22.481  -1.209  1.00  8.07           C  
+ANISOU 1129  CG  ASP A  37      770   1658    637    119   -161    -37       C  
+ATOM   1130  OD1 ASP A  37       3.314  21.640  -1.648  1.00  8.84           O  
+ANISOU 1130  OD1 ASP A  37      803   1976    579     91     38   -149       O  
+ATOM   1131  OD2 ASP A  37       2.277  23.586  -1.756  1.00  9.37           O  
+ANISOU 1131  OD2 ASP A  37      744   1881    936     45     -6      2       O  
+ATOM   1132  H  AASP A  37       1.533  20.469   2.486  0.97  7.85           H  
+ATOM   1133  H  BASP A  37       1.450  20.683   2.476  0.03  7.85           H  
+ATOM   1134  HA AASP A  37       1.751  20.110  -0.137  0.97  6.98           H  
+ATOM   1135  HA BASP A  37       1.758  20.106  -0.135  0.03  6.98           H  
+ATOM   1136  HB2 ASP A  37       0.758  22.240  -0.117  1.00  7.77           H  
+ATOM   1137  HB3 ASP A  37       1.932  22.774   0.760  1.00  7.77           H  
+ATOM   1138  N  APRO A  38       4.056  19.453   0.666  0.45  8.35           N  
+ANISOU 1138  N  APRO A  38     1054   1343    776    160    235   -294       N  
+ATOM   1139  N  BPRO A  38       4.017  19.388   0.790  0.55  8.07           N  
+ANISOU 1139  N  BPRO A  38     1038   1320    707    269     -3   -258       N  
+ATOM   1140  CA APRO A  38       5.451  19.296   1.073  0.45  9.77           C  
+ANISOU 1140  CA APRO A  38     1194   1488   1028    379     76   -199       C  
+ATOM   1141  CA BPRO A  38       5.390  19.157   1.245  0.55  8.11           C  
+ANISOU 1141  CA BPRO A  38      986   1331    764    502     40    -64       C  
+ATOM   1142  C  APRO A  38       6.401  20.321   0.438  0.45  7.81           C  
+ANISOU 1142  C  APRO A  38     1001   1323    642    260    133   -234       C  
+ATOM   1143  C  BPRO A  38       6.387  20.079   0.572  0.55  7.87           C  
+ANISOU 1143  C  BPRO A  38      920   1305    763    446    141   -185       C  
+ATOM   1144  O  APRO A  38       7.494  20.511   0.991  0.45  7.95           O  
+ANISOU 1144  O  APRO A  38      964   1381    675    207    -49   -385       O  
+ATOM   1145  O  BPRO A  38       7.500  20.224   1.065  0.55  7.68           O  
+ANISOU 1145  O  BPRO A  38      798   1204    916    417    -33      1       O  
+ATOM   1146  CB APRO A  38       5.781  17.860   0.637  0.45 12.10           C  
+ANISOU 1146  CB APRO A  38     1493   1548   1555    511    213   -250       C  
+ATOM   1147  CB BPRO A  38       5.639  17.673   0.917  0.55 12.36           C  
+ANISOU 1147  CB BPRO A  38     1479   1682   1535    587     69     -2       C  
+ATOM   1148  CG APRO A  38       4.488  17.154   0.642  0.45 12.74           C  
+ANISOU 1148  CG APRO A  38     1637   1609   1594    382     79   -412       C  
+ATOM   1149  CG BPRO A  38       4.289  17.043   0.952  0.55 12.37           C  
+ANISOU 1149  CG BPRO A  38     1560   1698   1441    418     27   -270       C  
+ATOM   1150  CD APRO A  38       3.462  18.170   0.254  0.45  9.37           C  
+ANISOU 1150  CD APRO A  38     1217   1252   1091    227    209   -424       C  
+ATOM   1151  CD BPRO A  38       3.338  18.118   0.462  0.55  9.63           C  
+ANISOU 1151  CD BPRO A  38     1317   1388    953    263    -43   -382       C  
+ATOM   1152  HA APRO A  38       5.569  19.451   2.023  0.45  8.11           H  
+ATOM   1153  HA BPRO A  38       5.505  19.350   2.189  0.55  8.11           H  
+ATOM   1154  HB2APRO A  38       6.186  17.845  -0.244  0.45 12.36           H  
+ATOM   1155  HB2BPRO A  38       6.053  17.570   0.046  0.55 12.36           H  
+ATOM   1156  HB3APRO A  38       6.411  17.444   1.246  0.45 12.36           H  
+ATOM   1157  HB3BPRO A  38       6.235  17.265   1.564  0.55 12.36           H  
+ATOM   1158  HG2APRO A  38       4.495  16.412   0.017  0.45 12.37           H  
+ATOM   1159  HG2BPRO A  38       4.254  16.258   0.384  0.55 12.37           H  
+ATOM   1160  HG3APRO A  38       4.297  16.785   1.519  0.45 12.37           H  
+ATOM   1161  HG3BPRO A  38       4.060  16.754   1.849  0.55 12.37           H  
+ATOM   1162  HD2APRO A  38       3.286  18.150  -0.700  0.45  9.63           H  
+ATOM   1163  HD2BPRO A  38       3.177  18.039  -0.491  0.55  9.63           H  
+ATOM   1164  HD3APRO A  38       2.617  18.010   0.702  0.45  9.63           H  
+ATOM   1165  HD3BPRO A  38       2.476  18.054   0.902  0.55  9.63           H  
+ATOM   1166  N  ASER A  39       6.012  20.953  -0.672  0.45  6.33           N  
+ANISOU 1166  N  ASER A  39      863   1091    450    111    201   -221       N  
+ATOM   1167  N  BSER A  39       6.007  20.684  -0.543  0.55  8.00           N  
+ANISOU 1167  N  BSER A  39      892   1391    755    350     34   -211       N  
+ATOM   1168  CA ASER A  39       6.903  21.914  -1.331  0.45  7.77           C  
+ANISOU 1168  CA ASER A  39      915   1435    602    107    117    -55       C  
+ATOM   1169  CA BSER A  39       6.915  21.598  -1.202  0.55  6.29           C  
+ANISOU 1169  CA BSER A  39      688   1162    540    262    154   -157       C  
+ATOM   1170  C  ASER A  39       7.191  23.114  -0.472  0.45  7.20           C  
+ANISOU 1170  C  ASER A  39      826   1414    496     96     37     38       C  
+ATOM   1171  C  BSER A  39       7.206  22.899  -0.438  0.55  6.80           C  
+ANISOU 1171  C  BSER A  39      778   1311    495    222     49   -113       C  
+ATOM   1172  O  ASER A  39       8.091  23.895  -0.791  0.45  8.08           O  
+ANISOU 1172  O  ASER A  39      890   1497    683    -38    190    177       O  
+ATOM   1173  O  BSER A  39       8.156  23.588  -0.826  0.55  6.76           O  
+ANISOU 1173  O  BSER A  39      745   1255    570    203    266   -102       O  
+ATOM   1174  CB ASER A  39       6.374  22.393  -2.683  0.45  7.49           C  
+ANISOU 1174  CB ASER A  39      886   1352    606      1     68     92       C  
+ATOM   1175  CB BSER A  39       6.470  21.897  -2.632  0.55  7.20           C  
+ANISOU 1175  CB BSER A  39      799   1271    665    210    181    -55       C  
+ATOM   1176  OG ASER A  39       5.373  23.389  -2.549  0.45  8.27           O  
+ANISOU 1176  OG ASER A  39      951   1441    749      4    -91    151       O  
+ATOM   1177  OG BSER A  39       5.381  22.811  -2.669  0.55  7.58           O  
+ANISOU 1177  OG BSER A  39      861   1352    667    156    109     76       O  
+ATOM   1178  H  ASER A  39       5.250  20.843  -1.055  0.45  8.00           H  
+ATOM   1179  H  BSER A  39       5.244  20.581  -0.926  0.55  8.00           H  
+ATOM   1180  HA ASER A  39       7.726  21.421  -1.478  0.45  6.29           H  
+ATOM   1181  HA BSER A  39       7.760  21.122  -1.221  0.55  6.29           H  
+ATOM   1182  HB2ASER A  39       7.109  22.745  -3.209  0.45  7.20           H  
+ATOM   1183  HB2BSER A  39       7.216  22.263  -3.133  0.55  7.20           H  
+ATOM   1184  HB3ASER A  39       6.012  21.638  -3.172  0.45  7.20           H  
+ATOM   1185  HB3BSER A  39       6.213  21.070  -3.070  0.55  7.20           H  
+ATOM   1186  HG ASER A  39       4.632  23.023  -2.400  0.45  7.58           H  
+ATOM   1187  HG BSER A  39       4.659  22.391  -2.580  0.55  7.58           H  
+ATOM   1188  N  AVAL A  40       6.448  23.272   0.612  0.92  6.06           N  
+ANISOU 1188  N  AVAL A  40      674   1121    508    104    142    -45       N  
+ATOM   1189  N  BVAL A  40       6.441  23.230   0.616  0.08  7.71           N  
+ANISOU 1189  N  BVAL A  40      887   1262    781    157     55    -40       N  
+ATOM   1190  CA  VAL A  40       6.705  24.424   1.455  1.00  6.34           C  
+ANISOU 1190  CA  VAL A  40      759    984    666    148    120     34       C  
+ATOM   1191  C   VAL A  40       7.636  24.087   2.630  1.00  5.49           C  
+ANISOU 1191  C   VAL A  40      698    923    466    130    221    -48       C  
+ATOM   1192  O   VAL A  40       7.812  24.907   3.537  1.00  5.89           O  
+ANISOU 1192  O   VAL A  40      735    928    575    144    191    -46       O  
+ATOM   1193  CB  VAL A  40       5.413  25.090   1.967  1.00  7.85           C  
+ANISOU 1193  CB  VAL A  40      840   1233    912    211     60   -148       C  
+ATOM   1194  CG1 VAL A  40       4.527  25.468   0.816  1.00  9.35           C  
+ANISOU 1194  CG1 VAL A  40     1085   1190   1279    322     -3     10       C  
+ATOM   1195  CG2 VAL A  40       4.652  24.248   2.982  1.00 10.34           C  
+ANISOU 1195  CG2 VAL A  40      961   1770   1198    158    123   -455       C  
+ATOM   1196  H  AVAL A  40       5.816  22.748   0.869  0.92  7.71           H  
+ATOM   1197  H  BVAL A  40       5.757  22.773   0.866  0.08  7.71           H  
+ATOM   1198  HA AVAL A  40       7.157  25.066   0.886  0.92  6.34           H  
+ATOM   1199  HA BVAL A  40       7.150  25.066   0.879  0.08  6.34           H  
+ATOM   1200  HB  VAL A  40       5.688  25.891   2.440  1.00  7.85           H  
+ATOM   1201 HG11 VAL A  40       3.719  25.885   1.153  1.00  9.35           H  
+ATOM   1202 HG12 VAL A  40       4.995  26.091   0.238  1.00  9.35           H  
+ATOM   1203 HG13 VAL A  40       4.294  24.673   0.312  1.00  9.35           H  
+ATOM   1204 HG21 VAL A  40       3.705  24.444   2.920  1.00 10.34           H  
+ATOM   1205 HG22 VAL A  40       4.800  23.308   2.798  1.00 10.34           H  
+ATOM   1206 HG23 VAL A  40       4.966  24.455   3.875  1.00 10.34           H  
+ATOM   1207  N   SER A  41       8.273  22.917   2.603  1.00  5.46           N  
+ANISOU 1207  N   SER A  41      839    844    393    178    156    -73       N  
+ATOM   1208  CA  SER A  41       9.046  22.475   3.727  1.00  5.57           C  
+ANISOU 1208  CA  SER A  41      899    813    404     83    233    -38       C  
+ATOM   1209  C   SER A  41      10.127  23.461   4.188  1.00  5.01           C  
+ANISOU 1209  C   SER A  41      756    751    397    222    227    -25       C  
+ATOM   1210  O   SER A  41      10.345  23.589   5.384  1.00  5.16           O  
+ANISOU 1210  O   SER A  41      784    850    326    163    133    -23       O  
+ATOM   1211  CB  SER A  41       9.638  21.099   3.439  1.00  6.45           C  
+ANISOU 1211  CB  SER A  41     1056    788    606    180     89    -16       C  
+ATOM   1212  OG  SER A  41      10.514  21.094   2.344  1.00  8.95           O  
+ANISOU 1212  OG  SER A  41     1089   1201   1108    274    105   -275       O  
+ATOM   1213  H   SER A  41       8.262  22.373   1.937  1.00  5.46           H  
+ATOM   1214  HA  SER A  41       8.430  22.421   4.474  1.00  5.57           H  
+ATOM   1215  HB2 SER A  41      10.111  20.785   4.226  1.00  6.45           H  
+ATOM   1216  HB3 SER A  41       8.917  20.471   3.272  1.00  6.45           H  
+ATOM   1217  HG  SER A  41      11.307  21.137   2.619  1.00  8.95           H  
+ATOM   1218  N  ALYS A  42      10.771  24.115   3.243  0.16  4.47           N  
+ANISOU 1218  N  ALYS A  42      654    760    285    185    145     41       N  
+ATOM   1219  N  BLYS A  42      10.894  24.085   3.271  0.30  6.08           N  
+ANISOU 1219  N  BLYS A  42      810    895    606    237    299   -139       N  
+ATOM   1220  N  CLYS A  42      10.758  24.127   3.243  0.40  4.32           N  
+ANISOU 1220  N  CLYS A  42      637    729    275    170    148     48       N  
+ATOM   1221  N  DLYS A  42      10.882  24.098   3.272  0.14  6.12           N  
+ANISOU 1221  N  DLYS A  42      818    907    602    241    302   -124       N  
+ATOM   1222  CA ALYS A  42      11.858  24.960   3.622  0.16  4.67           C  
+ANISOU 1222  CA ALYS A  42      599    799    374    191    208     48       C  
+ATOM   1223  CA BLYS A  42      12.003  25.004   3.668  0.30  5.45           C  
+ANISOU 1223  CA BLYS A  42      658    888    526    222    252    -71       C  
+ATOM   1224  CA CLYS A  42      11.858  24.960   3.622  0.40  4.72           C  
+ANISOU 1224  CA CLYS A  42      592    811    392    198    214     40       C  
+ATOM   1225  CA DLYS A  42      12.003  25.004   3.668  0.14  5.51           C  
+ANISOU 1225  CA DLYS A  42      670    888    535    215    258    -67       C  
+ATOM   1226  C  ALYS A  42      11.353  26.145   4.469  0.16  4.25           C  
+ANISOU 1226  C  ALYS A  42      510    723    381     63    239     51       C  
+ATOM   1227  C  BLYS A  42      11.491  26.101   4.591  0.30  4.54           C  
+ANISOU 1227  C  BLYS A  42      523    850    353    178    176     66       C  
+ATOM   1228  C  CLYS A  42      11.353  26.145   4.469  0.40  4.27           C  
+ANISOU 1228  C  CLYS A  42      520    712    390     39    247     74       C  
+ATOM   1229  C  DLYS A  42      11.491  26.101   4.591  0.14  4.70           C  
+ANISOU 1229  C  DLYS A  42      538    883    366    180    181     45       C  
+ATOM   1230  O  ALYS A  42      11.908  26.427   5.538  0.16  4.69           O  
+ANISOU 1230  O  ALYS A  42      516    856    409     81    227     25       O  
+ATOM   1231  O  BLYS A  42      12.048  26.350   5.676  0.30  5.01           O  
+ANISOU 1231  O  BLYS A  42      571    997    336    143    149     44       O  
+ATOM   1232  O  CLYS A  42      11.963  26.527   5.492  0.40  4.71           O  
+ANISOU 1232  O  CLYS A  42      526    834    428     56    192     29       O  
+ATOM   1233  O  DLYS A  42      12.160  26.465   5.572  0.14  4.91           O  
+ANISOU 1233  O  DLYS A  42      534    990    341    114    115      7       O  
+ATOM   1234  CB ALYS A  42      12.631  25.459   2.399  0.16  4.06           C  
+ANISOU 1234  CB ALYS A  42      537    620    385     95    251     -1       C  
+ATOM   1235  CB BLYS A  42      12.674  25.695   2.447  0.30  6.43           C  
+ANISOU 1235  CB BLYS A  42      796    993    653     22    311   -164       C  
+ATOM   1236  CB CLYS A  42      12.631  25.459   2.399  0.40  4.38           C  
+ANISOU 1236  CB CLYS A  42      577    699    389     85    260     12       C  
+ATOM   1237  CB DLYS A  42      12.674  25.695   2.447  0.14  6.52           C  
+ANISOU 1237  CB DLYS A  42      806    993    680     41    295   -141       C  
+ATOM   1238  CG ALYS A  42      13.300  24.386   1.546  0.16  4.86           C  
+ANISOU 1238  CG ALYS A  42      579    798    470    143    252    -67       C  
+ATOM   1239  CG BLYS A  42      13.932  26.561   2.745  0.30  6.89           C  
+ANISOU 1239  CG BLYS A  42      861    952    805      9    390    -24       C  
+ATOM   1240  CG CLYS A  42      13.139  24.384   1.443  0.40  4.71           C  
+ANISOU 1240  CG CLYS A  42      561    775    453     68    283    -83       C  
+ATOM   1241  CG DLYS A  42      14.009  26.446   2.722  0.14  7.46           C  
+ANISOU 1241  CG DLYS A  42      917   1044    875     28    349    -13       C  
+ATOM   1242  CD ALYS A  42      13.902  25.001   0.288  0.16  7.90           C  
+ANISOU 1242  CD ALYS A  42      916   1228    858     36    -25    -90       C  
+ATOM   1243  CD BLYS A  42      14.396  27.247   1.473  0.30  7.37           C  
+ANISOU 1243  CD BLYS A  42      939    947    915   -157    505     16       C  
+ATOM   1244  CD CLYS A  42      14.116  24.981   0.437  0.40  5.80           C  
+ANISOU 1244  CD CLYS A  42      655    996    554    116    176    -20       C  
+ATOM   1245  CD DLYS A  42      14.410  27.246   1.496  0.14  7.55           C  
+ANISOU 1245  CD DLYS A  42      950    978    939   -117    458     10       C  
+ATOM   1246  CE ALYS A  42      13.191  24.480  -0.971  0.16  5.31           C  
+ANISOU 1246  CE ALYS A  42      696    800    522    -87    264    -19       C  
+ATOM   1247  CE BLYS A  42      15.707  27.984   1.617  0.30  7.27           C  
+ANISOU 1247  CE BLYS A  42      954    947    862   -246    425    175       C  
+ATOM   1248  CE CLYS A  42      13.417  26.014  -0.460  0.40  4.64           C  
+ANISOU 1248  CE CLYS A  42      606    781    374    -19    268     28       C  
+ATOM   1249  CE DLYS A  42      14.430  28.740   1.719  0.14  8.42           C  
+ANISOU 1249  CE DLYS A  42     1094   1104   1000   -137    384     18       C  
+ATOM   1250  NZ ALYS A  42      12.159  25.480  -1.310  0.16  7.03           N  
+ANISOU 1250  NZ ALYS A  42      894   1054    723    -54    403    119       N  
+ATOM   1251  NZ BLYS A  42      15.653  29.102   2.511  0.30  8.76           N  
+ANISOU 1251  NZ BLYS A  42     1129   1101   1096   -182    558    103       N  
+ATOM   1252  NZ CLYS A  42      12.334  25.376  -1.198  0.40  7.29           N  
+ANISOU 1252  NZ CLYS A  42      934   1189    648   -113    411    139       N  
+ATOM   1253  NZ DLYS A  42      15.645  29.096   2.491  0.14 10.66           N  
+ANISOU 1253  NZ DLYS A  42     1319   1428   1305   -164    371     67       N  
+ATOM   1254  H  ALYS A  42      10.596  24.081   2.402  0.16  6.12           H  
+ATOM   1255  H  BLYS A  42      10.795  23.995   2.421  0.30  6.12           H  
+ATOM   1256  H  CLYS A  42      10.569  24.109   2.404  0.40  6.12           H  
+ATOM   1257  H  DLYS A  42      10.769  24.025   2.423  0.14  6.12           H  
+ATOM   1258  HA ALYS A  42      12.469  24.434   4.161  0.16  5.51           H  
+ATOM   1259  HA BLYS A  42      12.658  24.448   4.118  0.30  5.51           H  
+ATOM   1260  HA CLYS A  42      12.470  24.429   4.155  0.40  5.51           H  
+ATOM   1261  HA DLYS A  42      12.659  24.444   4.112  0.14  5.51           H  
+ATOM   1262  HB2ALYS A  42      12.021  25.961   1.836  0.16  6.52           H  
+ATOM   1263  HB2BLYS A  42      12.922  25.009   1.808  0.30  6.52           H  
+ATOM   1264  HB2CLYS A  42      12.059  26.064   1.902  0.40  6.52           H  
+ATOM   1265  HB2DLYS A  42      12.839  25.021   1.769  0.14  6.52           H  
+ATOM   1266  HB3ALYS A  42      13.313  26.079   2.701  0.16  6.52           H  
+ATOM   1267  HB3BLYS A  42      12.013  26.258   2.016  0.30  6.52           H  
+ATOM   1268  HB3CLYS A  42      13.391  25.977   2.708  0.40  6.52           H  
+ATOM   1269  HB3DLYS A  42      12.042  26.327   2.071  0.14  6.52           H  
+ATOM   1270  HG2ALYS A  42      13.994  23.943   2.059  0.16  7.46           H  
+ATOM   1271  HG2BLYS A  42      13.726  27.223   3.423  0.30  7.46           H  
+ATOM   1272  HG2CLYS A  42      13.575  23.677   1.945  0.40  7.46           H  
+ATOM   1273  HG2DLYS A  42      13.907  27.037   3.485  0.14  7.46           H  
+ATOM   1274  HG3ALYS A  42      12.651  23.708   1.302  0.16  7.46           H  
+ATOM   1275  HG3BLYS A  42      14.642  26.004   3.100  0.30  7.46           H  
+ATOM   1276  HG3CLYS A  42      12.391  23.980   0.975  0.40  7.46           H  
+ATOM   1277  HG3DLYS A  42      14.707  25.811   2.947  0.14  7.46           H  
+ATOM   1278  HD2ALYS A  42      13.829  25.967   0.329  0.16  7.55           H  
+ATOM   1279  HD2BLYS A  42      14.484  26.583   0.772  0.30  7.55           H  
+ATOM   1280  HD2CLYS A  42      14.853  25.401   0.907  0.40  7.55           H  
+ATOM   1281  HD2DLYS A  42      15.291  26.959   1.207  0.14  7.55           H  
+ATOM   1282  HD3ALYS A  42      14.848  24.790   0.241  0.16  7.55           H  
+ATOM   1283  HD3BLYS A  42      13.713  27.873   1.186  0.30  7.55           H  
+ATOM   1284  HD3CLYS A  42      14.494  24.275  -0.110  0.40  7.55           H  
+ATOM   1285  HD3DLYS A  42      13.795  27.044   0.774  0.14  7.55           H  
+ATOM   1286  HE2ALYS A  42      13.819  24.370  -1.702  0.16  8.42           H  
+ATOM   1287  HE2BLYS A  42      16.383  27.363   1.931  0.30  8.42           H  
+ATOM   1288  HE2CLYS A  42      13.067  26.740   0.080  0.40  8.42           H  
+ATOM   1289  HE2DLYS A  42      14.425  29.206   0.868  0.14  8.42           H  
+ATOM   1290  HE3ALYS A  42      12.791  23.612  -0.808  0.16  8.42           H  
+ATOM   1291  HE3BLYS A  42      15.990  28.294   0.743  0.30  8.42           H  
+ATOM   1292  HE3CLYS A  42      14.056  26.403  -1.078  0.40  8.42           H  
+ATOM   1293  HE3DLYS A  42      13.634  29.018   2.199  0.14  8.42           H  
+ATOM   1294  HZ1ALYS A  42      11.891  25.357  -2.150  0.16 10.66           H  
+ATOM   1295  HZ1BLYS A  42      16.453  29.490   2.550  0.30 10.66           H  
+ATOM   1296  HZ1CLYS A  42      12.096  25.893  -1.882  0.40 10.66           H  
+ATOM   1297  HZ1DLYS A  42      15.664  29.975   2.626  0.14 10.66           H  
+ATOM   1298  HZ2ALYS A  42      11.465  25.388  -0.761  0.16 10.66           H  
+ATOM   1299  HZ2BLYS A  42      15.053  29.690   2.216  0.30 10.66           H  
+ATOM   1300  HZ2CLYS A  42      12.608  24.587  -1.505  0.40 10.66           H  
+ATOM   1301  HZ2DLYS A  42      15.632  28.676   3.275  0.14 10.66           H  
+ATOM   1302  HZ3ALYS A  42      12.499  26.298  -1.224  0.16 10.66           H  
+ATOM   1303  HZ3BLYS A  42      15.419  28.822   3.323  0.30 10.66           H  
+ATOM   1304  HZ3CLYS A  42      11.636  25.258  -0.659  0.40 10.66           H  
+ATOM   1305  HZ3DLYS A  42      16.369  28.851   2.035  0.14 10.66           H  
+ATOM   1306  N  AGLU A  43      10.297  26.799   4.015  0.45  4.39           N  
+ANISOU 1306  N  AGLU A  43      516    722    430     84    248     70       N  
+ATOM   1307  N  BGLU A  43      10.443  26.763   4.114  0.55  4.43           N  
+ANISOU 1307  N  BGLU A  43      549    785    349     90    205     78       N  
+ATOM   1308  CA AGLU A  43       9.874  27.969   4.741  0.45  4.42           C  
+ANISOU 1308  CA AGLU A  43      629    585    465     96    308     76       C  
+ATOM   1309  CA BGLU A  43       9.917  27.937   4.779  0.55  5.69           C  
+ANISOU 1309  CA BGLU A  43      782    807    574    109    212    202       C  
+ATOM   1310  C  AGLU A  43       9.154  27.611   6.054  0.45  4.07           C  
+ANISOU 1310  C  AGLU A  43      608    494    444    158    231     64       C  
+ATOM   1311  C  BGLU A  43       9.287  27.565   6.121  0.55  4.00           C  
+ANISOU 1311  C  BGLU A  43      518    531    472    132    134    114       C  
+ATOM   1312  O  AGLU A  43       9.207  28.373   7.006  0.45  3.90           O  
+ANISOU 1312  O  AGLU A  43      535    471    477    172    251      9       O  
+ATOM   1313  O  BGLU A  43       9.523  28.232   7.130  0.55  3.79           O  
+ANISOU 1313  O  BGLU A  43      497    475    466     51    189     47       O  
+ATOM   1314  CB AGLU A  43       9.037  28.896   3.855  0.45  5.40           C  
+ANISOU 1314  CB AGLU A  43      755    719    576     94    248     19       C  
+ATOM   1315  CB BGLU A  43       8.905  28.648   3.869  0.55  6.45           C  
+ANISOU 1315  CB BGLU A  43      926    890    633    162    210    336       C  
+ATOM   1316  CG AGLU A  43       7.839  28.265   3.224  0.45  6.60           C  
+ANISOU 1316  CG AGLU A  43      832    965    713    179    159    222       C  
+ATOM   1317  CG BGLU A  43       9.561  29.377   2.676  0.55  9.33           C  
+ANISOU 1317  CG BGLU A  43     1255   1306    984    113     78    353       C  
+ATOM   1318  CD AGLU A  43       8.098  27.688   1.847  0.45  6.55           C  
+ANISOU 1318  CD AGLU A  43      827   1098    562    211    183    120       C  
+ATOM   1319  CD BGLU A  43      10.122  28.444   1.620  0.55  9.21           C  
+ANISOU 1319  CD BGLU A  43     1391   1308    802     92    421    379       C  
+ATOM   1320  OE1AGLU A  43       9.220  27.215   1.571  0.45  7.48           O  
+ANISOU 1320  OE1AGLU A  43      899   1125    820    233    434    104       O  
+ATOM   1321  OE1BGLU A  43       9.469  27.409   1.353  0.55  8.49           O  
+ANISOU 1321  OE1BGLU A  43     1159   1509    557     77    314    178       O  
+ATOM   1322  OE2AGLU A  43       7.166  27.645   1.041  0.45  7.09           O  
+ANISOU 1322  OE2AGLU A  43      892   1238    563    112    103     45       O  
+ATOM   1323  OE2BGLU A  43      11.218  28.757   1.041  0.55  9.41           O  
+ANISOU 1323  OE2BGLU A  43     1381   1460    733    193    496    192       O  
+ATOM   1324  H  AGLU A  43       9.833  26.592   3.321  0.45  4.43           H  
+ATOM   1325  H  BGLU A  43      10.021  26.542   3.398  0.55  4.43           H  
+ATOM   1326  HA AGLU A  43      10.673  28.456   4.996  0.45  5.69           H  
+ATOM   1327  HA BGLU A  43      10.649  28.548   4.959  0.55  5.69           H  
+ATOM   1328  HB2AGLU A  43       8.743  29.651   4.389  0.45  6.45           H  
+ATOM   1329  HB2BGLU A  43       8.270  27.997   3.532  0.55  6.45           H  
+ATOM   1330  HB3AGLU A  43       9.606  29.249   3.153  0.45  6.45           H  
+ATOM   1331  HB3BGLU A  43       8.402  29.290   4.395  0.55  6.45           H  
+ATOM   1332  HG2AGLU A  43       7.514  27.559   3.804  0.45  9.33           H  
+ATOM   1333  HG2BGLU A  43       8.905  29.960   2.264  0.55  9.33           H  
+ATOM   1334  HG3AGLU A  43       7.133  28.927   3.159  0.45  9.33           H  
+ATOM   1335  HG3BGLU A  43      10.275  29.943   3.007  0.55  9.33           H  
+ATOM   1336  N  AILE A  44       8.498  26.466   6.117  0.98  4.06           N  
+ANISOU 1336  N  AILE A  44      600    526    416     99    225     -3       N  
+ATOM   1337  N  BILE A  44       8.502  26.496   6.131  0.02  3.85           N  
+ANISOU 1337  N  BILE A  44      544    569    349     50    174    -52       N  
+ATOM   1338  CA  ILE A  44       7.881  26.026   7.361  1.00  3.88           C  
+ANISOU 1338  CA  ILE A  44      585    484    407     86    269    -17       C  
+ATOM   1339  C   ILE A  44       8.939  25.624   8.379  1.00  3.86           C  
+ANISOU 1339  C   ILE A  44      582    521    362    -61    257    -24       C  
+ATOM   1340  O   ILE A  44       8.837  25.974   9.556  1.00  4.38           O  
+ANISOU 1340  O   ILE A  44      619    670    375    -30    235    -63       O  
+ATOM   1341  CB  ILE A  44       6.867  24.887   7.071  1.00  4.18           C  
+ANISOU 1341  CB  ILE A  44      560    580    448     71    228    -35       C  
+ATOM   1342  CG1 ILE A  44       5.640  25.422   6.314  1.00  5.48           C  
+ANISOU 1342  CG1 ILE A  44      665    758    659    -44    154     58       C  
+ATOM   1343  CG2 ILE A  44       6.473  24.142   8.342  1.00  5.37           C  
+ANISOU 1343  CG2 ILE A  44      729    694    619    -77    159     75       C  
+ATOM   1344  CD1 ILE A  44       4.781  26.332   7.087  1.00 11.88           C  
+ANISOU 1344  CD1 ILE A  44     1107   1633   1774    108   -491    -78       C  
+ATOM   1345  H  AILE A  44       8.397  25.928   5.454  0.98  3.85           H  
+ATOM   1346  H  BILE A  44       8.316  26.027   5.434  0.02  3.85           H  
+ATOM   1347  HA AILE A  44       7.388  26.763   7.755  0.98  3.88           H  
+ATOM   1348  HA BILE A  44       7.375  26.755   7.753  0.02  3.88           H  
+ATOM   1349  HB  ILE A  44       7.306  24.241   6.496  1.00  4.18           H  
+ATOM   1350 HG12 ILE A  44       5.944  25.885   5.518  1.00  5.48           H  
+ATOM   1351 HG13 ILE A  44       5.106  24.669   6.017  1.00  5.48           H  
+ATOM   1352 HG21 ILE A  44       5.841  23.440   8.123  1.00  5.37           H  
+ATOM   1353 HG22 ILE A  44       7.263  23.750   8.746  1.00  5.37           H  
+ATOM   1354 HG23 ILE A  44       6.064  24.761   8.967  1.00  5.37           H  
+ATOM   1355 HD11 ILE A  44       4.036  26.620   6.537  1.00 11.88           H  
+ATOM   1356 HD12 ILE A  44       4.444  25.871   7.871  1.00 11.88           H  
+ATOM   1357 HD13 ILE A  44       5.296  27.106   7.364  1.00 11.88           H  
+ATOM   1358  N   LEU A  45       9.958  24.887   7.951  1.00  3.95           N  
+ANISOU 1358  N   LEU A  45      585    597    320     66    221    -32       N  
+ATOM   1359  CA  LEU A  45      11.030  24.522   8.866  1.00  3.92           C  
+ANISOU 1359  CA  LEU A  45      569    571    348     -8    191     18       C  
+ATOM   1360  C   LEU A  45      11.679  25.759   9.474  1.00  3.82           C  
+ANISOU 1360  C   LEU A  45      536    527    388     24    209    -43       C  
+ATOM   1361  O   LEU A  45      11.965  25.809  10.666  1.00  4.41           O  
+ANISOU 1361  O   LEU A  45      663    553    458      9    196    -38       O  
+ATOM   1362  CB  LEU A  45      12.068  23.665   8.156  1.00  4.29           C  
+ANISOU 1362  CB  LEU A  45      675    530    425     65    153    -15       C  
+ATOM   1363  CG  LEU A  45      13.275  23.280   9.018  1.00  4.49           C  
+ANISOU 1363  CG  LEU A  45      581    597    527     18    116      0       C  
+ATOM   1364  CD1 LEU A  45      12.872  22.431  10.217  1.00  5.12           C  
+ANISOU 1364  CD1 LEU A  45      668    692    584    -15    105    110       C  
+ATOM   1365  CD2 LEU A  45      14.318  22.563   8.184  1.00  5.65           C  
+ANISOU 1365  CD2 LEU A  45      673    769    704     92    109    -21       C  
+ATOM   1366  H   LEU A  45      10.047  24.593   7.148  1.00  3.95           H  
+ATOM   1367  HA  LEU A  45      10.644  24.003   9.589  1.00  3.92           H  
+ATOM   1368  HB2 LEU A  45      11.639  22.854   7.840  1.00  4.29           H  
+ATOM   1369  HB3 LEU A  45      12.384  24.143   7.373  1.00  4.29           H  
+ATOM   1370  HG  LEU A  45      13.659  24.102   9.362  1.00  4.49           H  
+ATOM   1371 HD11 LEU A  45      13.661  22.209  10.736  1.00  5.12           H  
+ATOM   1372 HD12 LEU A  45      12.250  22.928  10.771  1.00  5.12           H  
+ATOM   1373 HD13 LEU A  45      12.448  21.615   9.908  1.00  5.12           H  
+ATOM   1374 HD21 LEU A  45      15.074  22.327   8.744  1.00  5.65           H  
+ATOM   1375 HD22 LEU A  45      13.932  21.757   7.806  1.00  5.65           H  
+ATOM   1376 HD23 LEU A  45      14.616  23.145   7.468  1.00  5.65           H  
+ATOM   1377  N   ALA A  46      11.953  26.760   8.641  1.00  4.23           N  
+ANISOU 1377  N   ALA A  46      606    590    409    -18    219    -10       N  
+ATOM   1378  CA  ALA A  46      12.636  27.950   9.153  1.00  4.82           C  
+ANISOU 1378  CA  ALA A  46      635    584    613    -32    259     -5       C  
+ATOM   1379  C   ALA A  46      11.784  28.647  10.212  1.00  4.70           C  
+ANISOU 1379  C   ALA A  46      664    495    625    -46    233     47       C  
+ATOM   1380  O   ALA A  46      12.311  29.111  11.231  1.00  5.22           O  
+ANISOU 1380  O   ALA A  46      683    652    648   -131    185   -112       O  
+ATOM   1381  CB  ALA A  46      12.991  28.915   8.007  1.00  6.14           C  
+ANISOU 1381  CB  ALA A  46      794    752    785   -108    455     29       C  
+ATOM   1382  H   ALA A  46      11.760  26.774   7.803  1.00  4.23           H  
+ATOM   1383  HA  ALA A  46      13.464  27.668   9.571  1.00  4.82           H  
+ATOM   1384  HB1 ALA A  46      13.442  29.694   8.368  1.00  6.14           H  
+ATOM   1385  HB2 ALA A  46      13.576  28.467   7.376  1.00  6.14           H  
+ATOM   1386  HB3 ALA A  46      12.179  29.192   7.554  1.00  6.14           H  
+ATOM   1387  N   GLU A  47      10.468  28.727   9.998  1.00  4.19           N  
+ANISOU 1387  N   GLU A  47      605    504    481    -43    225    -50       N  
+ATOM   1388  CA  GLU A  47       9.586  29.322  10.998  1.00  4.14           C  
+ANISOU 1388  CA  GLU A  47      608    448    519     -4    224    -40       C  
+ATOM   1389  C   GLU A  47       9.604  28.497  12.294  1.00  4.06           C  
+ANISOU 1389  C   GLU A  47      547    531    465     12    195    -50       C  
+ATOM   1390  O   GLU A  47       9.669  29.047  13.398  1.00  4.79           O  
+ANISOU 1390  O   GLU A  47      780    545    494    -27    188   -100       O  
+ATOM   1391  CB  GLU A  47       8.147  29.424  10.496  1.00  4.27           C  
+ANISOU 1391  CB  GLU A  47      709    420    492     22    266    -39       C  
+ATOM   1392  CG  GLU A  47       7.958  30.417   9.375  1.00  4.64           C  
+ANISOU 1392  CG  GLU A  47      823    400    539     73    225    -20       C  
+ATOM   1393  CD  GLU A  47       6.497  30.594   8.985  1.00  4.75           C  
+ANISOU 1393  CD  GLU A  47      895    466    445     78     97    -48       C  
+ATOM   1394  OE1 GLU A  47       5.692  29.694   9.369  1.00  5.57           O  
+ANISOU 1394  OE1 GLU A  47      898    547    671    -66     15     48       O  
+ATOM   1395  OE2 GLU A  47       6.143  31.593   8.331  1.00  5.67           O  
+ANISOU 1395  OE2 GLU A  47     1030    501    624     54     34      1       O  
+ATOM   1396  H   GLU A  47      10.072  28.445   9.288  1.00  4.19           H  
+ATOM   1397  HA  GLU A  47       9.919  30.217  11.171  1.00  4.14           H  
+ATOM   1398  HB2 GLU A  47       7.857  28.549  10.193  1.00  4.27           H  
+ATOM   1399  HB3 GLU A  47       7.572  29.673  11.237  1.00  4.27           H  
+ATOM   1400  HG2 GLU A  47       8.323  31.275   9.643  1.00  4.64           H  
+ATOM   1401  HG3 GLU A  47       8.462  30.124   8.600  1.00  4.64           H  
+ATOM   1402  N   ALA A  48       9.505  27.180  12.150  1.00  3.87           N  
+ANISOU 1402  N   ALA A  48      599    477    395    -14    191    -44       N  
+ATOM   1403  CA  ALA A  48       9.455  26.303  13.301  1.00  3.96           C  
+ANISOU 1403  CA  ALA A  48      561    545    398    -10    216    -34       C  
+ATOM   1404  C   ALA A  48      10.724  26.424  14.132  1.00  3.98           C  
+ANISOU 1404  C   ALA A  48      649    478    383    -91    174    -32       C  
+ATOM   1405  O   ALA A  48      10.656  26.424  15.371  1.00  4.38           O  
+ANISOU 1405  O   ALA A  48      708    595    362   -108    194    -54       O  
+ATOM   1406  CB  ALA A  48       9.227  24.871  12.851  1.00  4.08           C  
+ANISOU 1406  CB  ALA A  48      615    513    423    -35    175     15       C  
+ATOM   1407  H   ALA A  48       9.466  26.778  11.391  1.00  3.87           H  
+ATOM   1408  HA  ALA A  48       8.712  26.570  13.865  1.00  3.96           H  
+ATOM   1409  HB1 ALA A  48       9.195  24.289  13.626  1.00  4.08           H  
+ATOM   1410  HB2 ALA A  48       8.388  24.813  12.368  1.00  4.08           H  
+ATOM   1411  HB3 ALA A  48       9.953  24.595  12.270  1.00  4.08           H  
+ATOM   1412  N   LYS A  49      11.871  26.517  13.482  1.00  4.48           N  
+ANISOU 1412  N   LYS A  49      668    634    401    -67    152    -98       N  
+ATOM   1413  CA  LYS A  49      13.131  26.664  14.198  1.00  5.28           C  
+ANISOU 1413  CA  LYS A  49      674    908    423   -108     72    -79       C  
+ATOM   1414  C  ALYS A  49      13.174  27.996  14.941  0.35  5.22           C  
+ANISOU 1414  C  ALYS A  49      627    863    492   -156    291    -23       C  
+ATOM   1415  C  BLYS A  49      13.206  27.997  14.961  0.15  6.71           C  
+ANISOU 1415  C  BLYS A  49      773   1112    666   -272    329   -109       C  
+ATOM   1416  C  CLYS A  49      13.206  27.983  14.946  0.50  5.28           C  
+ANISOU 1416  C  CLYS A  49      619   1044    344   -298     96   -106       C  
+ATOM   1417  O  ALYS A  49      13.610  28.043  16.095  0.35  6.89           O  
+ANISOU 1417  O  ALYS A  49      757   1164    697   -341    198   -263       O  
+ATOM   1418  O  BLYS A  49      13.688  28.030  16.095  0.15  6.60           O  
+ANISOU 1418  O  BLYS A  49      778   1245    484   -335    198   -227       O  
+ATOM   1419  O  CLYS A  49      13.683  28.022  16.089  0.50  6.18           O  
+ANISOU 1419  O  CLYS A  49      757   1171    419   -294    153   -182       O  
+ATOM   1420  CB  LYS A  49      14.310  26.506  13.254  1.00  5.63           C  
+ANISOU 1420  CB  LYS A  49      651    937    553   -133    167   -100       C  
+ATOM   1421  CG  LYS A  49      14.467  25.070  12.755  1.00  6.74           C  
+ANISOU 1421  CG  LYS A  49      790   1101    669     13     36   -103       C  
+ATOM   1422  CD  LYS A  49      15.542  24.930  11.726  1.00  7.74           C  
+ANISOU 1422  CD  LYS A  49      946   1129    864      6    266   -230       C  
+ATOM   1423  CE  LYS A  49      16.911  25.267  12.219  1.00  9.49           C  
+ANISOU 1423  CE  LYS A  49      946   1337   1321   -180    183   -318       C  
+ATOM   1424  NZ  LYS A  49      17.242  24.434  13.403  1.00 14.88           N  
+ANISOU 1424  NZ  LYS A  49     1637   2050   1968   -167   -685   -238       N  
+ATOM   1425  H   LYS A  49      11.945  26.497  12.625  1.00  4.48           H  
+ATOM   1426  HA ALYS A  49      13.195  25.958  14.860  0.35  5.28           H  
+ATOM   1427  HA BLYS A  49      13.174  25.955  14.859  0.15  5.28           H  
+ATOM   1428  HA CLYS A  49      13.173  25.956  14.860  0.50  5.28           H  
+ATOM   1429  HB2 LYS A  49      14.195  27.099  12.495  1.00  5.63           H  
+ATOM   1430  HB3 LYS A  49      15.123  26.779  13.707  1.00  5.63           H  
+ATOM   1431  HG2 LYS A  49      14.667  24.491  13.507  1.00  6.74           H  
+ATOM   1432  HG3 LYS A  49      13.625  24.768  12.380  1.00  6.74           H  
+ATOM   1433  HD2 LYS A  49      15.544  24.018  11.397  1.00  7.74           H  
+ATOM   1434  HD3 LYS A  49      15.331  25.503  10.972  1.00  7.74           H  
+ATOM   1435  HE2 LYS A  49      17.562  25.117  11.516  1.00  9.49           H  
+ATOM   1436  HE3 LYS A  49      16.957  26.207  12.452  1.00  9.49           H  
+ATOM   1437  HZ1 LYS A  49      18.125  24.404  13.508  1.00 14.88           H  
+ATOM   1438  HZ2 LYS A  49      16.869  24.788  14.129  1.00 14.88           H  
+ATOM   1439  HZ3 LYS A  49      16.930  23.609  13.282  1.00 14.88           H  
+ATOM   1440  N  ALYS A  50      12.708  29.071  14.313  0.50  5.36           N  
+ANISOU 1440  N  ALYS A  50      750    813    473   -186    305   -102       N  
+ATOM   1441  N  BLYS A  50      12.727  29.088  14.366  0.21  5.98           N  
+ANISOU 1441  N  BLYS A  50      787    901    583   -183    233    -63       N  
+ATOM   1442  N  CLYS A  50      12.725  29.064  14.351  0.29  5.81           N  
+ANISOU 1442  N  CLYS A  50      754    879    577   -211    266   -141       N  
+ATOM   1443  CA ALYS A  50      12.655  30.364  14.989  0.50  6.29           C  
+ANISOU 1443  CA ALYS A  50      895    817    679   -381    325   -101       C  
+ATOM   1444  CA BLYS A  50      12.729  30.373  15.065  0.21  6.02           C  
+ANISOU 1444  CA BLYS A  50      830    758    699   -280    290   -117       C  
+ATOM   1445  CA CLYS A  50      12.741  30.338  15.053  0.29  5.51           C  
+ANISOU 1445  CA CLYS A  50      783    692    618   -333    303   -161       C  
+ATOM   1446  C  ALYS A  50      11.830  30.266  16.277  0.50  5.66           C  
+ANISOU 1446  C  ALYS A  50      912    672    567   -381    253   -104       C  
+ATOM   1447  C  BLYS A  50      11.844  30.315  16.307  0.21  5.77           C  
+ANISOU 1447  C  BLYS A  50      901    662    628   -271    250   -162       C  
+ATOM   1448  C  CLYS A  50      11.796  30.355  16.257  0.29  5.96           C  
+ANISOU 1448  C  CLYS A  50      919    691    655   -323    317   -153       C  
+ATOM   1449  O  ALYS A  50      12.258  30.699  17.367  0.50  6.17           O  
+ANISOU 1449  O  ALYS A  50      961    729    655   -376    275   -126       O  
+ATOM   1450  O  BLYS A  50      12.204  30.821  17.377  0.21  5.96           O  
+ANISOU 1450  O  BLYS A  50      935    696    633   -266    255   -271       O  
+ATOM   1451  O  CLYS A  50      12.058  31.022  17.254  0.29  6.15           O  
+ANISOU 1451  O  CLYS A  50      943    729    666   -223    352   -262       O  
+ATOM   1452  CB ALYS A  50      12.080  31.447  14.054  0.50  9.71           C  
+ANISOU 1452  CB ALYS A  50     1305   1278   1106   -434    302    -69       C  
+ATOM   1453  CB BLYS A  50      12.252  31.514  14.151  0.21  5.01           C  
+ANISOU 1453  CB BLYS A  50      737    545    619   -235    356    -98       C  
+ATOM   1454  CB CLYS A  50      12.394  31.473  14.099  0.29  5.61           C  
+ANISOU 1454  CB CLYS A  50      859    666    607   -341    318   -147       C  
+ATOM   1455  CG ALYS A  50      13.097  31.999  13.060  0.50  9.35           C  
+ANISOU 1455  CG ALYS A  50     1276   1133   1142   -405    358    -83       C  
+ATOM   1456  CG BLYS A  50      13.138  31.821  12.932  0.21  7.96           C  
+ANISOU 1456  CG BLYS A  50     1050    954   1019   -354    381    -98       C  
+ATOM   1457  CG CLYS A  50      13.575  31.927  13.243  0.29  5.40           C  
+ANISOU 1457  CG CLYS A  50      777    602    672   -274    364    -99       C  
+ATOM   1458  CD ALYS A  50      12.542  33.065  12.137  0.50 10.91           C  
+ANISOU 1458  CD ALYS A  50     1450   1360   1336   -309    400    155       C  
+ATOM   1459  CD BLYS A  50      14.625  31.905  13.275  0.21  8.54           C  
+ANISOU 1459  CD BLYS A  50     1130    957   1157   -272    477      2       C  
+ATOM   1460  CD CLYS A  50      13.192  33.057  12.296  0.29  6.29           C  
+ANISOU 1460  CD CLYS A  50      800    708    881   -295    311    124       C  
+ATOM   1461  CE ALYS A  50      13.567  33.471  11.090  0.50 10.85           C  
+ANISOU 1461  CE ALYS A  50     1415   1335   1371   -379    576    221       C  
+ATOM   1462  CE BLYS A  50      14.891  33.109  14.130  0.21  8.98           C  
+ANISOU 1462  CE BLYS A  50     1190   1035   1187   -306    442     32       C  
+ATOM   1463  CE CLYS A  50      14.410  33.538  11.512  0.29  8.22           C  
+ANISOU 1463  CE CLYS A  50     1107    972   1043   -293    539     74       C  
+ATOM   1464  NZ ALYS A  50      13.886  32.375  10.122  0.50 12.31           N  
+ANISOU 1464  NZ ALYS A  50     1535   1572   1570   -456    369    212       N  
+ATOM   1465  NZ BLYS A  50      16.302  33.291  14.558  0.21 10.08           N  
+ANISOU 1465  NZ BLYS A  50     1280   1242   1308   -422    187     17       N  
+ATOM   1466  NZ CLYS A  50      14.070  34.737  10.691  0.29  8.55           N  
+ANISOU 1466  NZ CLYS A  50     1153   1006   1092   -227    593    108       N  
+ATOM   1467  H  ALYS A  50      12.420  29.074  13.503  0.50  5.81           H  
+ATOM   1468  H  BLYS A  50      12.401  29.107  13.570  0.21  5.81           H  
+ATOM   1469  H  CLYS A  50      12.392  29.084  13.559  0.29  5.81           H  
+ATOM   1470  HA ALYS A  50      13.560  30.620  15.226  0.50  5.51           H  
+ATOM   1471  HA BLYS A  50      13.645  30.552  15.330  0.21  5.51           H  
+ATOM   1472  HA CLYS A  50      13.641  30.463  15.392  0.29  5.51           H  
+ATOM   1473  HB2ALYS A  50      11.329  31.076  13.565  0.50  5.61           H  
+ATOM   1474  HB2BLYS A  50      11.361  31.299  13.834  0.21  5.61           H  
+ATOM   1475  HB2CLYS A  50      11.672  31.188  13.517  0.29  5.61           H  
+ATOM   1476  HB3ALYS A  50      11.735  32.177  14.591  0.50  5.61           H  
+ATOM   1477  HB3BLYS A  50      12.176  32.321  14.684  0.21  5.61           H  
+ATOM   1478  HB3CLYS A  50      12.065  32.228  14.611  0.29  5.61           H  
+ATOM   1479  HG2ALYS A  50      13.848  32.368  13.551  0.50  5.40           H  
+ATOM   1480  HG2BLYS A  50      13.005  31.133  12.261  0.21  5.40           H  
+ATOM   1481  HG2CLYS A  50      14.298  32.220  13.820  0.29  5.40           H  
+ATOM   1482  HG3ALYS A  50      13.441  31.268  12.524  0.50  5.40           H  
+ATOM   1483  HG3BLYS A  50      12.855  32.661  12.537  0.21  5.40           H  
+ATOM   1484  HG3CLYS A  50      13.909  31.175  12.730  0.29  5.40           H  
+ATOM   1485  HD2ALYS A  50      11.742  32.734  11.699  0.50  6.29           H  
+ATOM   1486  HD2BLYS A  50      14.902  31.101  13.741  0.21  6.29           H  
+ATOM   1487  HD2CLYS A  50      12.506  32.752  11.682  0.29  6.29           H  
+ATOM   1488  HD3ALYS A  50      12.280  33.842  12.656  0.50  6.29           H  
+ATOM   1489  HD3BLYS A  50      15.149  31.956  12.461  0.21  6.29           H  
+ATOM   1490  HD3CLYS A  50      12.814  33.794  12.801  0.29  6.29           H  
+ATOM   1491  HE2ALYS A  50      13.234  34.240  10.601  0.50  8.22           H  
+ATOM   1492  HE2BLYS A  50      14.613  33.900  13.643  0.21  8.22           H  
+ATOM   1493  HE2CLYS A  50      15.130  33.754  12.125  0.29  8.22           H  
+ATOM   1494  HE3ALYS A  50      14.383  33.749  11.535  0.50  8.22           H  
+ATOM   1495  HE3BLYS A  50      14.334  33.053  14.922  0.21  8.22           H  
+ATOM   1496  HE3CLYS A  50      14.731  32.827  10.936  0.29  8.22           H  
+ATOM   1497  HZ1ALYS A  50      14.432  32.685   9.491  0.50  8.55           H  
+ATOM   1498  HZ1BLYS A  50      16.369  34.024  15.058  0.21  8.55           H  
+ATOM   1499  HZ1CLYS A  50      14.790  35.003  10.241  0.29  8.55           H  
+ATOM   1500  HZ2ALYS A  50      14.282  31.704  10.553  0.50  8.55           H  
+ATOM   1501  HZ2BLYS A  50      16.562  32.584  15.032  0.21  8.55           H  
+ATOM   1502  HZ2CLYS A  50      13.422  34.530  10.117  0.29  8.55           H  
+ATOM   1503  HZ3ALYS A  50      13.134  32.083   9.745  0.50  8.55           H  
+ATOM   1504  HZ3BLYS A  50      16.822  33.374  13.840  0.21  8.55           H  
+ATOM   1505  HZ3CLYS A  50      13.794  35.394  11.224  0.29  8.55           H  
+ATOM   1506  N  ALEU A  51      10.643  29.700  16.144  0.63  4.72           N  
+ANISOU 1506  N  ALEU A  51      851    563    380   -179    154   -109       N  
+ATOM   1507  N  BLEU A  51      10.676  29.708  16.159  0.16  5.48           N  
+ANISOU 1507  N  BLEU A  51      939    531    613   -154    374   -145       N  
+ATOM   1508  N  CLEU A  51      10.687  29.641  16.162  0.21  8.08           N  
+ANISOU 1508  N  CLEU A  51     1255    847    969   -176    295    -87       N  
+ATOM   1509  CA  LEU A  51       9.736  29.597  17.261  1.00  6.06           C  
+ANISOU 1509  CA  LEU A  51      854    778    671   -196    263   -188       C  
+ATOM   1510  C   LEU A  51      10.310  28.685  18.365  1.00  5.07           C  
+ANISOU 1510  C   LEU A  51      755    614    558   -203    351   -135       C  
+ATOM   1511  O   LEU A  51      10.197  28.968  19.561  1.00  6.33           O  
+ANISOU 1511  O   LEU A  51     1112    764    528   -100    361   -156       O  
+ATOM   1512  CB  LEU A  51       8.380  29.104  16.753  1.00  5.87           C  
+ANISOU 1512  CB  LEU A  51      781    654    795   -191    372   -171       C  
+ATOM   1513  CG  LEU A  51       7.262  28.977  17.788  1.00  6.42           C  
+ANISOU 1513  CG  LEU A  51      875    716    848   -160    400    -11       C  
+ATOM   1514  CD1 LEU A  51       7.079  30.272  18.579  1.00  7.65           C  
+ANISOU 1514  CD1 LEU A  51     1029    924    955     69    581     73       C  
+ATOM   1515  CD2 LEU A  51       5.978  28.559  17.066  1.00  8.49           C  
+ANISOU 1515  CD2 LEU A  51      873   1155   1199   -289    305     90       C  
+ATOM   1516  H  ALEU A  51      10.345  29.368  15.409  0.63  8.08           H  
+ATOM   1517  H  BLEU A  51      10.408  29.352  15.424  0.16  8.08           H  
+ATOM   1518  H  CLEU A  51      10.465  29.176  15.473  0.21  8.08           H  
+ATOM   1519  HA ALEU A  51       9.617  30.470  17.666  0.63  6.06           H  
+ATOM   1520  HA BLEU A  51       9.597  30.473  17.654  0.16  6.06           H  
+ATOM   1521  HA CLEU A  51       9.596  30.481  17.634  0.21  6.06           H  
+ATOM   1522  HB2 LEU A  51       8.080  29.709  16.056  1.00  5.87           H  
+ATOM   1523  HB3 LEU A  51       8.509  28.236  16.339  1.00  5.87           H  
+ATOM   1524  HG  LEU A  51       7.496  28.298  18.440  1.00  6.42           H  
+ATOM   1525 HD11 LEU A  51       6.365  30.159  19.225  1.00  7.65           H  
+ATOM   1526 HD12 LEU A  51       7.903  30.487  19.043  1.00  7.65           H  
+ATOM   1527 HD13 LEU A  51       6.853  30.993  17.971  1.00  7.65           H  
+ATOM   1528 HD21 LEU A  51       5.258  28.474  17.710  1.00  8.49           H  
+ATOM   1529 HD22 LEU A  51       5.744  29.231  16.407  1.00  8.49           H  
+ATOM   1530 HD23 LEU A  51       6.118  27.707  16.624  1.00  8.49           H  
+ATOM   1531  N   ASN A  52      10.919  27.565  17.964  1.00  4.95           N  
+ANISOU 1531  N   ASN A  52      787    668    428   -192    244   -183       N  
+ATOM   1532  CA  ASN A  52      11.588  26.693  18.913  1.00  4.78           C  
+ANISOU 1532  CA  ASN A  52      760    588    467   -183    230   -127       C  
+ATOM   1533  C   ASN A  52      12.651  27.457  19.714  1.00  5.61           C  
+ANISOU 1533  C   ASN A  52      919    758    454   -286    217   -191       C  
+ATOM   1534  O   ASN A  52      12.760  27.325  20.928  1.00  6.66           O  
+ANISOU 1534  O   ASN A  52     1100    996    433   -366    155   -196       O  
+ATOM   1535  CB  ASN A  52      12.244  25.512  18.167  1.00  4.78           C  
+ANISOU 1535  CB  ASN A  52      718    678    421   -162    186   -167       C  
+ATOM   1536  CG  ASN A  52      13.007  24.633  19.099  1.00  5.33           C  
+ANISOU 1536  CG  ASN A  52      839    791    393   -125    125   -158       C  
+ATOM   1537  OD1 ASN A  52      12.435  23.798  19.785  1.00  6.17           O  
+ANISOU 1537  OD1 ASN A  52     1064    786    495   -172    117    -71       O  
+ATOM   1538  ND2 ASN A  52      14.323  24.853  19.158  1.00  6.64           N  
+ANISOU 1538  ND2 ASN A  52      829   1133    560    -69     52    -19       N  
+ATOM   1539  H   ASN A  52      10.952  27.299  17.147  1.00  4.95           H  
+ATOM   1540  HA  ASN A  52      10.924  26.356  19.535  1.00  4.78           H  
+ATOM   1541  HB2 ASN A  52      11.560  24.992  17.717  1.00  4.78           H  
+ATOM   1542  HB3 ASN A  52      12.839  25.852  17.481  1.00  4.78           H  
+ATOM   1543 HD21 ASN A  52      14.812  24.396  19.698  1.00  6.64           H  
+ATOM   1544 HD22 ASN A  52      14.682  25.452  18.656  1.00  6.64           H  
+ATOM   1545  N   ASP A  53      13.473  28.214  18.993  1.00  5.92           N  
+ANISOU 1545  N   ASP A  53      802    953    494   -248    173   -155       N  
+ATOM   1546  CA  ASP A  53      14.607  28.873  19.631  1.00  6.90           C  
+ANISOU 1546  CA  ASP A  53      905   1010    707   -344    214   -185       C  
+ATOM   1547  C   ASP A  53      14.104  29.955  20.584  1.00  7.47           C  
+ANISOU 1547  C   ASP A  53      939   1142    758   -488     69   -245       C  
+ATOM   1548  O   ASP A  53      14.666  30.136  21.675  1.00  9.01           O  
+ANISOU 1548  O   ASP A  53     1152   1439    832   -482    -81   -366       O  
+ATOM   1549  CB  ASP A  53      15.511  29.479  18.559  1.00  7.96           C  
+ANISOU 1549  CB  ASP A  53      897   1236    894   -460    256   -186       C  
+ATOM   1550  CG  ASP A  53      16.193  28.411  17.669  1.00 10.33           C  
+ANISOU 1550  CG  ASP A  53     1069   1539   1315   -302    373    -68       C  
+ATOM   1551  OD1 ASP A  53      16.087  27.177  17.971  1.00 10.60           O  
+ANISOU 1551  OD1 ASP A  53     1191   1603   1232   -127    164   -188       O  
+ATOM   1552  OD2 ASP A  53      16.836  28.832  16.689  1.00 11.85           O  
+ANISOU 1552  OD2 ASP A  53     1249   1800   1452   -242    570    -19       O  
+ATOM   1553  H   ASP A  53      13.394  28.357  18.149  1.00  5.92           H  
+ATOM   1554  HA  ASP A  53      15.118  28.225  20.142  1.00  6.90           H  
+ATOM   1555  HB2 ASP A  53      14.987  30.073  17.999  1.00  7.96           H  
+ATOM   1556  HB3 ASP A  53      16.193  30.020  18.986  1.00  7.96           H  
+ATOM   1557  N   ALA A  54      13.028  30.642  20.216  1.00  6.91           N  
+ANISOU 1557  N   ALA A  54     1142    897    586   -446    199   -224       N  
+ATOM   1558  CA  ALA A  54      12.471  31.688  21.056  1.00  7.65           C  
+ANISOU 1558  CA  ALA A  54     1257    861    788   -410    105   -286       C  
+ATOM   1559  C   ALA A  54      11.904  31.142  22.371  1.00  7.56           C  
+ANISOU 1559  C   ALA A  54     1270    912    691   -448    238   -343       C  
+ATOM   1560  O   ALA A  54      11.884  31.838  23.363  1.00 10.31           O  
+ANISOU 1560  O   ALA A  54     1894   1106    917   -572    366   -400       O  
+ATOM   1561  CB  ALA A  54      11.400  32.440  20.297  1.00  9.70           C  
+ANISOU 1561  CB  ALA A  54     1492   1137   1057   -300    378   -446       C  
+ATOM   1562  H   ALA A  54      12.605  30.515  19.478  1.00  6.91           H  
+ATOM   1563  HA  ALA A  54      13.194  32.291  21.287  1.00  7.65           H  
+ATOM   1564  HB1 ALA A  54      11.032  33.137  20.862  1.00  9.70           H  
+ATOM   1565  HB2 ALA A  54      11.786  32.839  19.502  1.00  9.70           H  
+ATOM   1566  HB3 ALA A  54      10.694  31.826  20.039  1.00  9.70           H  
+ATOM   1567  N   GLN A  55      11.518  29.887  22.386  1.00  6.15           N  
+ANISOU 1567  N   GLN A  55      935    884    516   -271    115   -228       N  
+ATOM   1568  CA  GLN A  55      10.869  29.248  23.532  1.00  5.95           C  
+ANISOU 1568  CA  GLN A  55      917    884    460   -189    121   -217       C  
+ATOM   1569  C  AGLN A  55      11.807  28.348  24.335  0.80  6.12           C  
+ANISOU 1569  C  AGLN A  55      927    959    437   -265    -37   -228       C  
+ATOM   1570  C  BGLN A  55      11.798  28.310  24.310  0.20  6.11           C  
+ANISOU 1570  C  BGLN A  55      962    986    371   -211     75   -202       C  
+ATOM   1571  O  AGLN A  55      11.358  27.595  25.182  0.80  6.58           O  
+ANISOU 1571  O  AGLN A  55      942   1024    535   -173     12   -154       O  
+ATOM   1572  O  BGLN A  55      11.316  27.523  25.116  0.20  6.86           O  
+ANISOU 1572  O  BGLN A  55     1005   1088    514   -250     49   -139       O  
+ATOM   1573  CB  GLN A  55       9.620  28.505  23.079  1.00  5.00           C  
+ANISOU 1573  CB  GLN A  55      717    714    470   -109    122   -100       C  
+ATOM   1574  CG  GLN A  55       8.534  29.430  22.529  1.00  5.37           C  
+ANISOU 1574  CG  GLN A  55      862    700    479    -30    164   -169       C  
+ATOM   1575  CD  GLN A  55       7.290  28.696  22.061  1.00  4.67           C  
+ANISOU 1575  CD  GLN A  55      697    661    415     25    214    -29       C  
+ATOM   1576  OE1 GLN A  55       6.184  28.846  22.527  1.00  7.82           O  
+ANISOU 1576  OE1 GLN A  55      767   1483    720    130    176   -361       O  
+ATOM   1577  NE2 GLN A  55       7.493  27.892  21.039  1.00  6.60           N  
+ANISOU 1577  NE2 GLN A  55      634    881    993    -28    104   -342       N  
+ATOM   1578  H   GLN A  55      11.624  29.359  21.716  1.00  6.15           H  
+ATOM   1579  HA AGLN A  55      10.608  29.954  24.144  0.80  5.95           H  
+ATOM   1580  HA BGLN A  55      10.624  29.958  24.145  0.20  5.95           H  
+ATOM   1581  HB2 GLN A  55       9.864  27.861  22.396  1.00  5.00           H  
+ATOM   1582  HB3 GLN A  55       9.260  28.003  23.827  1.00  5.00           H  
+ATOM   1583  HG2 GLN A  55       8.285  30.068  23.216  1.00  5.37           H  
+ATOM   1584  HG3 GLN A  55       8.898  29.939  21.788  1.00  5.37           H  
+ATOM   1585 HE21 GLN A  55       8.285  27.796  20.718  1.00  6.60           H  
+ATOM   1586 HE22 GLN A  55       6.833  27.463  20.692  1.00  6.60           H  
+ATOM   1587  N  AALA A  56      13.112  28.442  24.080  0.50  6.96           N  
+ANISOU 1587  N  AALA A  56      860   1167    616   -192   -348   -107       N  
+ATOM   1588  N  BALA A  56      13.116  28.382  24.095  0.50  7.64           N  
+ANISOU 1588  N  BALA A  56     1050   1230    624   -113    386   -168       N  
+ATOM   1589  CA AALA A  56      14.091  27.603  24.782  0.50  7.39           C  
+ANISOU 1589  CA AALA A  56      914   1251    642    -99   -162   -216       C  
+ATOM   1590  CA BALA A  56      14.014  27.467  24.802  0.50  7.12           C  
+ANISOU 1590  CA BALA A  56      939   1187    577    -54     63   -226       C  
+ATOM   1591  C  AALA A  56      14.118  27.855  26.293  0.50  7.20           C  
+ANISOU 1591  C  AALA A  56      849   1230    656    -44   -107   -369       C  
+ATOM   1592  C  BALA A  56      14.064  27.837  26.272  0.50  7.20           C  
+ANISOU 1592  C  BALA A  56      827   1246    663    -37    -98   -373       C  
+ATOM   1593  O  AALA A  56      14.029  29.005  26.731  0.50  8.14           O  
+ANISOU 1593  O  AALA A  56     1037   1263    795   -128   -203   -304       O  
+ATOM   1594  O  BALA A  56      13.891  29.002  26.646  0.50  8.10           O  
+ANISOU 1594  O  BALA A  56      976   1305    798    -57   -211   -265       O  
+ATOM   1595  CB AALA A  56      15.457  27.839  24.197  0.50  8.35           C  
+ANISOU 1595  CB AALA A  56     1032   1312    827    -85   -105   -123       C  
+ATOM   1596  CB BALA A  56      15.404  27.487  24.200  0.50  8.75           C  
+ANISOU 1596  CB BALA A  56     1096   1317    912    -60    -30   -130       C  
+ATOM   1597  H  AALA A  56      13.453  28.984  23.506  0.50  7.64           H  
+ATOM   1598  H  BALA A  56      13.500  28.936  23.561  0.50  7.64           H  
+ATOM   1599  HA AALA A  56      13.823  26.679  24.659  0.50  7.12           H  
+ATOM   1600  HA BALA A  56      13.669  26.565  24.711  0.50  7.12           H  
+ATOM   1601  HB1AALA A  56      16.107  27.286  24.659  0.50  8.75           H  
+ATOM   1602  HB1BALA A  56      15.976  26.873  24.687  0.50  8.75           H  
+ATOM   1603  HB2AALA A  56      15.450  27.610  23.254  0.50  8.75           H  
+ATOM   1604  HB2BALA A  56      15.358  27.217  23.270  0.50  8.75           H  
+ATOM   1605  HB3AALA A  56      15.697  28.773  24.300  0.50  8.75           H  
+ATOM   1606  HB3BALA A  56      15.769  28.384  24.258  0.50  8.75           H  
+ATOM   1607  N  APRO A  57      14.298  26.801  27.098  0.50  7.45           N  
+ANISOU 1607  N  APRO A  57      970   1301    561    -15   -101   -155       N  
+ATOM   1608  N  BPRO A  57      14.336  26.861  27.124  0.50  7.83           N  
+ANISOU 1608  N  BPRO A  57     1012   1339    623    -11   -107   -151       N  
+ATOM   1609  CA APRO A  57      14.490  27.048  28.519  0.50  7.59           C  
+ANISOU 1609  CA APRO A  57     1031   1290    562    -65   -164   -257       C  
+ATOM   1610  CA BPRO A  57      14.481  27.162  28.541  0.50  8.57           C  
+ANISOU 1610  CA BPRO A  57     1129   1400    726    -70    -86   -172       C  
+ATOM   1611  C  APRO A  57      15.718  27.922  28.724  0.50  7.22           C  
+ANISOU 1611  C  APRO A  57      959   1275    508    -95   -306   -132       C  
+ATOM   1612  C  BPRO A  57      15.619  28.178  28.802  0.50  9.75           C  
+ANISOU 1612  C  BPRO A  57     1180   1683    842   -231   -103    -93       C  
+ATOM   1613  O  APRO A  57      16.739  27.754  28.037  0.50  9.29           O  
+ANISOU 1613  O  APRO A  57      960   1725    844   -137     43   -188       O  
+ATOM   1614  O  BPRO A  57      16.613  28.224  28.070  0.50 10.73           O  
+ANISOU 1614  O  BPRO A  57     1126   1996    954   -266    -53   -179       O  
+ATOM   1615  CB APRO A  57      14.812  25.667  29.096  0.50 10.33           C  
+ANISOU 1615  CB APRO A  57     1432   1528    963     74    -77    -73       C  
+ATOM   1616  CB BPRO A  57      14.821  25.798  29.152  0.50 11.29           C  
+ANISOU 1616  CB BPRO A  57     1547   1633   1109     39    -36    -99       C  
+ATOM   1617  CG APRO A  57      14.370  24.723  28.091  0.50 10.65           C  
+ANISOU 1617  CG APRO A  57     1417   1547   1083    196   -146    -88       C  
+ATOM   1618  CG BPRO A  57      14.355  24.796  28.145  0.50 10.78           C  
+ANISOU 1618  CG BPRO A  57     1435   1543   1117    188   -135    -70       C  
+ATOM   1619  CD APRO A  57      14.471  25.387  26.777  0.50  8.82           C  
+ANISOU 1619  CD APRO A  57     1196   1328    829     21   -123   -249       C  
+ATOM   1620  CD BPRO A  57      14.453  25.429  26.830  0.50  9.17           C  
+ANISOU 1620  CD BPRO A  57     1222   1390    873     53   -171   -212       C  
+ATOM   1621  HA APRO A  57      13.721  27.480  28.923  0.50  8.57           H  
+ATOM   1622  HA BPRO A  57      13.686  27.570  28.918  0.50  8.57           H  
+ATOM   1623  HB2APRO A  57      15.761  25.573  29.271  0.50 11.29           H  
+ATOM   1624  HB2BPRO A  57      15.773  25.714  29.316  0.50 11.29           H  
+ATOM   1625  HB3APRO A  57      14.352  25.523  29.938  0.50 11.29           H  
+ATOM   1626  HB3BPRO A  57      14.374  25.674  30.004  0.50 11.29           H  
+ATOM   1627  HG2APRO A  57      14.918  23.923  28.111  0.50 10.78           H  
+ATOM   1628  HG2BPRO A  57      14.901  23.995  28.181  0.50 10.78           H  
+ATOM   1629  HG3APRO A  57      13.457  24.446  28.263  0.50 10.78           H  
+ATOM   1630  HG3BPRO A  57      13.442  24.526  28.328  0.50 10.78           H  
+ATOM   1631  HD2APRO A  57      15.328  25.218  26.356  0.50  9.17           H  
+ATOM   1632  HD2BPRO A  57      15.296  25.222  26.397  0.50  9.17           H  
+ATOM   1633  HD3APRO A  57      13.788  25.073  26.164  0.50  9.17           H  
+ATOM   1634  HD3BPRO A  57      13.747  25.128  26.236  0.50  9.17           H  
+ATOM   1635  N  ALYS A  58      15.624  28.840  29.688  0.50  9.13           N  
+ANISOU 1635  N  ALYS A  58     1203   1486    781   -150   -144   -287       N  
+ATOM   1636  N  BLYS A  58      15.456  28.995  29.847  0.50  8.93           N  
+ANISOU 1636  N  BLYS A  58     1239   1490    665   -219   -192   -172       N  
+ATOM   1637  CA ALYS A  58      16.752  29.695  30.072  0.50 10.25           C  
+ANISOU 1637  CA ALYS A  58     1432   1463    999   -217   -205   -295       C  
+ATOM   1638  CA BLYS A  58      16.500  29.927  30.315  0.50  9.91           C  
+ANISOU 1638  CA BLYS A  58     1432   1441    894   -296   -413   -158       C  
+ATOM   1639  C  ALYS A  58      16.884  29.568  31.570  0.50  8.08           C  
+ANISOU 1639  C  ALYS A  58     1238   1032    801   -179   -256   -355       C  
+ATOM   1640  C  BLYS A  58      16.776  29.696  31.769  0.50  7.76           C  
+ANISOU 1640  C  BLYS A  58     1259   1067    620   -149   -173   -242       C  
+ATOM   1641  O  ALYS A  58      15.877  29.248  32.198  0.50  9.32           O  
+ANISOU 1641  O  ALYS A  58     1491   1178    874   -122   -164   -428       O  
+ATOM   1642  O  BLYS A  58      15.809  29.417  32.470  0.50  8.44           O  
+ANISOU 1642  O  BLYS A  58     1382   1229    595   -151   -223   -222       O  
+ATOM   1643  CB ALYS A  58      16.492  31.172  29.722  0.50 11.18           C  
+ANISOU 1643  CB ALYS A  58     1535   1407   1305   -279     21    298       C  
+ATOM   1644  CB BLYS A  58      16.056  31.386  30.151  0.50 12.97           C  
+ANISOU 1644  CB BLYS A  58     1692   1663   1572   -265   -250    190       C  
+ATOM   1645  CG ALYS A  58      16.587  31.596  28.270  0.50 14.48           C  
+ANISOU 1645  CG ALYS A  58     1906   1749   1846   -179    166    434       C  
+ATOM   1646  CG BLYS A  58      16.129  31.878  28.735  0.50 15.13           C  
+ANISOU 1646  CG BLYS A  58     1983   1881   1884   -211     52    418       C  
+ATOM   1647  CD ALYS A  58      16.344  33.110  28.215  0.50 17.93           C  
+ANISOU 1647  CD ALYS A  58     2299   2226   2287   -123    135    375       C  
+ATOM   1648  CD BLYS A  58      15.810  33.345  28.650  0.50 17.52           C  
+ANISOU 1648  CD BLYS A  58     2259   2153   2243   -140    133    338       C  
+ATOM   1649  CE ALYS A  58      16.823  33.797  26.947  0.50 18.76           C  
+ANISOU 1649  CE ALYS A  58     2387   2352   2390   -109    129    267       C  
+ATOM   1650  CE BLYS A  58      15.895  33.813  27.215  0.50 19.27           C  
+ANISOU 1650  CE BLYS A  58     2440   2443   2440    -97     87    250       C  
+ATOM   1651  NZ ALYS A  58      16.591  35.273  27.055  0.50 18.70           N  
+ANISOU 1651  NZ ALYS A  58     2341   2378   2387   -104    102    180       N  
+ATOM   1652  NZ BLYS A  58      15.656  35.275  27.116  0.50 18.55           N  
+ANISOU 1652  NZ BLYS A  58     2324   2361   2362    -96    151    186       N  
+ATOM   1653  OXTALYS A  58      17.938  29.837  32.164  0.50  7.36           O  
+ANISOU 1653  OXTALYS A  58     1276    847    672     -2   -140   -277       O  
+ATOM   1654  OXTBLYS A  58      17.903  29.852  32.256  0.50  7.25           O  
+ANISOU 1654  OXTBLYS A  58     1122    798    836    170   -222   -255       O  
+ATOM   1655  H  ALYS A  58      14.905  28.985  30.138  0.50  8.93           H  
+ATOM   1656  H  BLYS A  58      14.732  29.027  30.310  0.50  8.93           H  
+ATOM   1657  HA ALYS A  58      17.553  29.420  29.598  0.50  9.91           H  
+ATOM   1658  HA BLYS A  58      17.294  29.765  29.781  0.50  9.91           H  
+ATOM   1659  HB2ALYS A  58      15.604  31.399  30.038  0.50 12.97           H  
+ATOM   1660  HB2BLYS A  58      15.145  31.477  30.471  0.50 12.97           H  
+ATOM   1661  HB3ALYS A  58      17.120  31.711  30.229  0.50 12.97           H  
+ATOM   1662  HB3BLYS A  58      16.611  31.951  30.711  0.50 12.97           H  
+ATOM   1663  HG2ALYS A  58      17.459  31.377  27.907  0.50 15.13           H  
+ATOM   1664  HG2BLYS A  58      17.017  31.717  28.380  0.50 15.13           H  
+ATOM   1665  HG3ALYS A  58      15.930  31.125  27.733  0.50 15.13           H  
+ATOM   1666  HG3BLYS A  58      15.508  31.377  28.184  0.50 15.13           H  
+ATOM   1667  HD2ALYS A  58      15.393  33.274  28.315  0.50 17.52           H  
+ATOM   1668  HD2BLYS A  58      14.920  33.511  28.999  0.50 17.52           H  
+ATOM   1669  HD3ALYS A  58      16.785  33.522  28.975  0.50 17.52           H  
+ATOM   1670  HD3BLYS A  58      16.429  33.850  29.200  0.50 17.52           H  
+ATOM   1671  HE2ALYS A  58      17.766  33.618  26.808  0.50 19.27           H  
+ATOM   1672  HE2BLYS A  58      16.769  33.600  26.853  0.50 19.27           H  
+ATOM   1673  HE3ALYS A  58      16.351  33.442  26.178  0.50 19.27           H  
+ATOM   1674  HE3BLYS A  58      15.242  33.338  26.677  0.50 19.27           H  
+ATOM   1675  HZ1ALYS A  58      16.872  35.673  26.311  0.50 18.55           H  
+ATOM   1676  HZ1BLYS A  58      15.711  35.528  26.264  0.50 18.55           H  
+ATOM   1677  HZ2ALYS A  58      15.722  35.430  27.165  0.50 18.55           H  
+ATOM   1678  HZ2BLYS A  58      14.845  35.465  27.430  0.50 18.55           H  
+ATOM   1679  HZ3ALYS A  58      17.041  35.594  27.753  0.50 18.55           H  
+ATOM   1680  HZ3BLYS A  58      16.269  35.709  27.594  0.50 18.55           H  
+TER    1681      LYS A  58                                                      
+HETATM 1682 ZN    ZN A 101      17.919  29.932  34.195  1.00  5.56          ZN  
+ANISOU 1682 ZN    ZN A 101      942    434    737    -17   -103    -22      ZN  
+HETATM 1683 ZN    ZN A 102       9.507  19.547  24.373  0.40 29.99          ZN  
+ANISOU 1683 ZN    ZN A 102     3799   3799   3799      0      0      0      ZN  
+HETATM 1684  S   SCN A 103      15.650  26.105  35.922  1.00  8.13           S  
+ANISOU 1684  S   SCN A 103     1202    777   1108   -284   -308    340       S  
+HETATM 1685  C   SCN A 103      16.526  27.581  35.477  1.00  6.60           C  
+ANISOU 1685  C   SCN A 103      993    669    846     62   -189     62       C  
+HETATM 1686  N   SCN A 103      17.089  28.530  35.191  1.00  7.16           N  
+ANISOU 1686  N   SCN A 103     1096    469   1153   -143     13    165       N  
+HETATM 1687  O   HOH A 201       2.264  25.988  13.825  1.00  5.18           O  
+ANISOU 1687  O   HOH A 201      834    434    700     56    127    -17       O  
+HETATM 1688  O   HOH A 202       7.565  33.800   7.851  1.00  6.78           O  
+ANISOU 1688  O   HOH A 202      969    657    948    103    366    122       O  
+HETATM 1689  O   HOH A 203      10.379  30.854   6.592  1.00  7.21           O  
+ANISOU 1689  O   HOH A 203     1186    664    891    -44    481    -37       O  
+HETATM 1690  O  CHOH A 204      12.806  22.871  -2.789  0.82  6.18           O  
+ANISOU 1690  O  CHOH A 204      819   1043    488    -14    355     21       O  
+HETATM 1691  O   HOH A 205       0.373  26.495  21.453  1.00  7.30           O  
+ANISOU 1691  O   HOH A 205     1006    681   1085     80    511     73       O  
+HETATM 1692  O   HOH A 206      10.139  24.887   0.419  1.00  7.88           O  
+ANISOU 1692  O   HOH A 206     1138   1274    583     71    183     37       O  
+HETATM 1693  O   HOH A 207      14.561  18.791  16.105  1.00 10.42           O  
+ANISOU 1693  O   HOH A 207      881   2018   1061     -5   -140    162       O  
+HETATM 1694  O   HOH A 208      14.640  25.624   5.792  1.00 11.75           O  
+ANISOU 1694  O   HOH A 208      781   2100   1583    281    301    749       O  
+HETATM 1695  O   HOH A 209      11.367  31.864   9.044  1.00  9.46           O  
+ANISOU 1695  O   HOH A 209     1363    802   1428    -35     53     74       O  
+HETATM 1696  O   HOH A 210       2.481  24.107  -4.426  1.00 13.61           O  
+ANISOU 1696  O   HOH A 210      995   3038   1137    163    179    691       O  
+HETATM 1697  O   HOH A 211      -2.378  22.704  15.667  1.00 12.16           O  
+ANISOU 1697  O   HOH A 211      884   2208   1527    -90    -31   -461       O  
+HETATM 1698  O   HOH A 212      14.983  29.787  10.996  1.00 13.36           O  
+ANISOU 1698  O   HOH A 212      987   1727   2361   -509    362   -550       O  
+HETATM 1699  O   HOH A 213      12.868  21.234   3.620  1.00  9.92           O  
+ANISOU 1699  O   HOH A 213     1317   1220   1233     89    217    261       O  
+HETATM 1700  O   HOH A 214      10.865  22.934  26.191  1.00 12.23           O  
+ANISOU 1700  O   HOH A 214     1789   2072    785    178    164    -21       O  
+HETATM 1701  O  AHOH A 215      -0.438  17.583  12.496  0.85 11.29           O  
+ANISOU 1701  O  AHOH A 215     1952   1086   1250   -631    117    -37       O  
+HETATM 1702  O   HOH A 216       3.929  15.074  16.562  1.00 10.83           O  
+ANISOU 1702  O   HOH A 216     1105    785   2223    -56    115    171       O  
+HETATM 1703  O   HOH A 217      10.379  20.953  -0.525  1.00 12.27           O  
+ANISOU 1703  O   HOH A 217     1504   1997   1163    516    435    279       O  
+HETATM 1704  O   HOH A 218      16.654  20.771  15.592  1.00 12.50           O  
+ANISOU 1704  O   HOH A 218     1549   1896   1306   -123     -1    -84       O  
+HETATM 1705  O   HOH A 219      10.062  22.794  -2.919  1.00 11.79           O  
+ANISOU 1705  O   HOH A 219     1126   2271   1084   -247    508   -148       O  
+HETATM 1706  O   HOH A 220      18.223  22.511  10.491  1.00 13.11           O  
+ANISOU 1706  O   HOH A 220     1316   1394   2272   -265    278    117       O  
+HETATM 1707  O   HOH A 221       7.742  20.666  23.868  1.00 14.33           O  
+ANISOU 1707  O   HOH A 221     1296   2506   1643    269    126    860       O  
+HETATM 1708  O  CHOH A 222       2.238  16.308  18.412  0.87 11.93           O  
+ANISOU 1708  O  CHOH A 222     1715   1372   1447     87    202     69       O  
+HETATM 1709  O   HOH A 223      12.378  31.391   4.740  1.00 14.61           O  
+ANISOU 1709  O   HOH A 223     1987   1581   1982   -369   1143   -125       O  
+HETATM 1710  O   HOH A 224      15.884  25.110  15.869  1.00 11.63           O  
+ANISOU 1710  O   HOH A 224     1790   1503   1126   -206     11    -88       O  
+HETATM 1711  O   HOH A 225      16.182  19.564   8.633  1.00 13.25           O  
+ANISOU 1711  O   HOH A 225     1659   1350   2025   -152     19   -391       O  
+HETATM 1712  O   HOH A 226       2.612  16.808  14.817  1.00 15.81           O  
+ANISOU 1712  O   HOH A 226     2447   1412   2148    642   1252    669       O  
+HETATM 1713  O   HOH A 227      15.651  26.052   8.430  1.00 12.78           O  
+ANISOU 1713  O   HOH A 227     1270   1942   1643    -61    469    356       O  
+HETATM 1714  O   HOH A 228      -2.884  18.782  -0.397  1.00 13.91           O  
+ANISOU 1714  O   HOH A 228     1923   1703   1660   -456   -746    555       O  
+HETATM 1715  O   HOH A 229      16.456  28.438   9.239  1.00 18.53           O  
+ANISOU 1715  O   HOH A 229     1553   2621   2865   -331    808   -528       O  
+HETATM 1716  O   HOH A 230      17.776  24.368   8.628  1.00 12.99           O  
+ANISOU 1716  O   HOH A 230     1504   1752   1680     82    297    257       O  
+HETATM 1717  O   HOH A 231       3.541  19.259  -3.106  1.00 14.99           O  
+ANISOU 1717  O   HOH A 231     2052   2301   1343    525   -242   -655       O  
+HETATM 1718  O   HOH A 232      16.744  23.975   2.686  1.00 13.18           O  
+ANISOU 1718  O   HOH A 232     1343   2220   1446     49    327    -53       O  
+HETATM 1719  O  BHOH A 233       6.092  25.554  -2.923  0.92 16.79           O  
+ANISOU 1719  O  BHOH A 233     2066   2711   1601    -33    147    181       O  
+HETATM 1720  O   HOH A 234      -1.524  24.071   9.740  1.00 15.06           O  
+ANISOU 1720  O   HOH A 234     1031   2121   2571    342   -133    836       O  
+HETATM 1721  O   HOH A 235      17.196  23.068  16.984  1.00 16.66           O  
+ANISOU 1721  O   HOH A 235     2331   2070   1930    142   -597   -369       O  
+HETATM 1722  O   HOH A 236       7.848  27.048  -1.587  1.00 15.25           O  
+ANISOU 1722  O   HOH A 236     2181   2386   1227    536    268    -12       O  
+HETATM 1723  O  AHOH A 237      16.099  15.975  10.358  0.88 12.84           O  
+ANISOU 1723  O  AHOH A 237     1549   1847   1483    559   -313    -75       O  
+HETATM 1724  O   HOH A 238      -3.162  20.651  17.640  1.00 15.81           O  
+ANISOU 1724  O   HOH A 238     1456   2170   2381   -592    637   -366       O  
+HETATM 1725  O   HOH A 239      17.159  22.677   0.297  1.00 14.45           O  
+ANISOU 1725  O   HOH A 239     1878   2116   1496   -122    544   -261       O  
+HETATM 1726  O   HOH A 240      13.253  10.445   1.910  1.00 16.25           O  
+ANISOU 1726  O   HOH A 240     2328   2710   1135    867    480   -122       O  
+HETATM 1727  O   HOH A 241      16.407  15.950  -1.246  1.00 18.08           O  
+ANISOU 1727  O   HOH A 241     2139   2987   1743    -35    937    521       O  
+HETATM 1728  O   HOH A 242      16.444  20.786   6.146  1.00 18.63           O  
+ANISOU 1728  O   HOH A 242     2058   2686   2334   -221    752   -448       O  
+HETATM 1729  O   HOH A 243      15.474  14.288  14.646  1.00 17.72           O  
+ANISOU 1729  O   HOH A 243     1536   2309   2886   -145    823    491       O  
+HETATM 1730  O   HOH A 244       1.327  15.157   1.258  1.00 17.28           O  
+ANISOU 1730  O   HOH A 244     3170   1408   1987    531    -36   -208       O  
+HETATM 1731  O   HOH A 245      17.410  29.318  21.808  1.00 15.99           O  
+ANISOU 1731  O   HOH A 245     1489   2314   2274   -342    192   -130       O  
+HETATM 1732  O   HOH A 246      17.852  22.801   6.440  1.00 18.67           O  
+ANISOU 1732  O   HOH A 246     2567   2340   2188    -83    917   -327       O  
+HETATM 1733  O   HOH A 247      17.779  19.274   4.078  1.00 18.22           O  
+ANISOU 1733  O   HOH A 247     1706   2481   2736     72    291   -101       O  
+HETATM 1734  O  AHOH A 248      -3.077  21.480  13.249  0.80 17.69           O  
+ANISOU 1734  O  AHOH A 248     2380   2299   2044   -183   -302   -656       O  
+HETATM 1735  O   HOH A 249       6.817  22.923  -6.176  1.00 21.78           O  
+ANISOU 1735  O   HOH A 249     2898   3203   2173    -86    -46    -57       O  
+HETATM 1736  O   HOH A 250      -0.847  16.473   9.971  1.00 18.59           O  
+ANISOU 1736  O   HOH A 250     2758   2424   1883  -1142   -202   -278       O  
+HETATM 1737  O   HOH A 251      15.193  20.180   4.392  1.00 18.45           O  
+ANISOU 1737  O   HOH A 251     2697   2011   2301   -852   -144    174       O  
+HETATM 1738  O   HOH A 252      -0.225  27.204  13.283  1.00 15.99           O  
+ANISOU 1738  O   HOH A 252     1756   2222   2098    311    400    300       O  
+HETATM 1739  O   HOH A 253       0.026  16.996  -0.718  1.00 21.05           O  
+ANISOU 1739  O   HOH A 253     2748   2818   2433     -8   -305   -404       O  
+HETATM 1740  O   HOH A 254      13.607  14.509  -5.750  1.00 21.36           O  
+ANISOU 1740  O   HOH A 254     2772   2486   2856    120    285    463       O  
+HETATM 1741  O   HOH A 255      17.548  19.962  19.783  1.00 19.36           O  
+ANISOU 1741  O   HOH A 255     2553   2867   1937   -186    -97    275       O  
+HETATM 1742  O   HOH A 256       0.825  14.192  -5.759  1.00 21.83           O  
+ANISOU 1742  O   HOH A 256     3019   2382   2892    372   -964    635       O  
+HETATM 1743  O  AHOH A 257      15.930  13.814  -2.444  0.85 18.83           O  
+ANISOU 1743  O  AHOH A 257     2494   2807   1854     14   1044   -470       O  
+HETATM 1744  O   HOH A 258       3.987  22.584  -5.844  1.00 18.08           O  
+ANISOU 1744  O   HOH A 258     2499   2586   1784    168   -221   -211       O  
+HETATM 1745  O   HOH A 259       5.991  17.890  -3.057  1.00 21.62           O  
+ANISOU 1745  O   HOH A 259     2836   2883   2494    312   -434   -182       O  
+HETATM 1746  O   HOH A 260      15.581  12.638   7.541  1.00 21.96           O  
+ANISOU 1746  O   HOH A 260     2704   2701   2939   -305   -612   -279       O  
+HETATM 1747  O   HOH A 261      18.017  27.331  14.775  1.00 20.32           O  
+ANISOU 1747  O   HOH A 261     2580   2498   2643   -577    576   -571       O  
+HETATM 1748  O   HOH A 262      -3.587  17.277   3.547  1.00 26.43           O  
+ANISOU 1748  O   HOH A 262     3238   3338   3466   -339    306    175       O  
+HETATM 1749  O   HOH A 263      18.979  28.325  10.202  1.00 25.69           O  
+ANISOU 1749  O   HOH A 263     2993   3444   3324   -157    120   -120       O  
+HETATM 1750  O   HOH A 264       9.565  20.875  26.281  1.00 21.46           O  
+ANISOU 1750  O   HOH A 264     3121   2725   2309   -185   -221   -162       O  
+HETATM 1751  O   HOH A 265       6.656  16.178  21.820  1.00 23.14           O  
+ANISOU 1751  O   HOH A 265     3177   2880   2737    228    705    254       O  
+HETATM 1752  O   HOH A 266      10.460  12.278  -3.594  1.00 26.63           O  
+ANISOU 1752  O   HOH A 266     3264   3436   3420    108   -199   -274       O  
+HETATM 1753  O   HOH A 267      15.900  17.998  18.400  1.00 19.24           O  
+ANISOU 1753  O   HOH A 267     2189   2704   2418    325   -331    334       O  
+HETATM 1754  O   HOH A 268      12.084  16.583  -5.418  1.00 26.21           O  
+ANISOU 1754  O   HOH A 268     3576   3461   2920   -256   -208    -79       O  
+HETATM 1755  O   HOH A 269      -3.430  23.168  11.186  1.00 21.72           O  
+ANISOU 1755  O   HOH A 269     2366   3229   2656    609     88    -92       O  
+HETATM 1756  O   HOH A 270      -4.611  11.637   5.532  1.00 22.86           O  
+ANISOU 1756  O   HOH A 270     2738   2833   3113    -11     25   -257       O  
+HETATM 1757  O   HOH A 271       8.359  32.357   5.611  1.00 15.62           O  
+ANISOU 1757  O   HOH A 271     2267   2561   1106   1293    300    205       O  
+HETATM 1758  O   HOH A 272      10.416  24.235  28.512  1.00 17.25           O  
+ANISOU 1758  O   HOH A 272     2502   2419   1632   -334    441     34       O  
+HETATM 1759  O   HOH A 273       4.781  15.240  21.036  0.29 21.48           O  
+ANISOU 1759  O   HOH A 273     2647   2733   2783      9    153     19       O  
+HETATM 1760  O   HOH A 274      17.954  26.694  21.054  1.00 22.59           O  
+ANISOU 1760  O   HOH A 274     2699   2896   2988   -569    247   -101       O  
+HETATM 1761  O  AHOH A 275       4.687  19.549  24.321  0.90 22.75           O  
+ANISOU 1761  O  AHOH A 275     3230   3016   2397   -180    214    445       O  
+HETATM 1762  O   HOH A 276      -5.267  16.664   5.849  1.00 28.37           O  
+ANISOU 1762  O   HOH A 276     3521   3631   3626   -179    168   -111       O  
+HETATM 1763  O   HOH A 277       8.890  15.614  20.055  1.00 15.80           O  
+ANISOU 1763  O   HOH A 277     2344   2685    976   -543   -268    542       O  
+HETATM 1764  O   HOH A 278      19.957  18.903   5.989  1.00 23.72           O  
+ANISOU 1764  O   HOH A 278     2779   3084   3148   -279    134    479       O  
+HETATM 1765  O   HOH A 279      11.133  26.854  27.781  0.69 11.68           O  
+ANISOU 1765  O   HOH A 279     1717   1628   1094    207    -81   -248       O  
+HETATM 1766  O   HOH A 280      18.567  19.284   1.553  1.00 27.91           O  
+ANISOU 1766  O   HOH A 280     3538   3515   3551     90   -273    160       O  
+HETATM 1767  O   HOH A 281      -3.469  25.286  22.398  1.00 21.36           O  
+ANISOU 1767  O   HOH A 281     2801   2973   2343    510    497     79       O  
+HETATM 1768  O   HOH A 282      15.524  32.317  23.368  1.00 28.87           O  
+ANISOU 1768  O   HOH A 282     3707   3649   3614   -133    -41   -310       O  
+HETATM 1769  O   HOH A 283       4.819  28.985   1.339  0.58  9.58           O  
+ANISOU 1769  O   HOH A 283     1108   1280   1253    105     48    -52       O  
+HETATM 1770  O  BHOH A 284       5.253  28.456   3.339  0.55 17.73           O  
+ANISOU 1770  O  BHOH A 284     2097   2193   2447     47    340   -684       O  
+HETATM 1771  O   HOH A 285      15.951  12.030  13.175  1.00 23.34           O  
+ANISOU 1771  O   HOH A 285     2815   2778   3276     68   -137   -498       O  
+HETATM 1772  O   HOH A 286      13.763  31.428  25.597  1.00 19.74           O  
+ANISOU 1772  O   HOH A 286     3036   1818   2646   -327   -934   -718       O  
+HETATM 1773  O   HOH A 287      -5.187  25.132  20.351  1.00 26.79           O  
+ANISOU 1773  O   HOH A 287     3359   3431   3390   -193    338   -124       O  
+HETATM 1774  O   HOH A 288      10.410  25.429  26.562  0.70 24.23           O  
+ANISOU 1774  O   HOH A 288     3129   3135   2942   -172    207    457       O  
+HETATM 1775  O   HOH A 289      18.991  19.558  15.807  1.00 25.64           O  
+ANISOU 1775  O   HOH A 289     2972   3358   3413    550     67     74       O  
+HETATM 1776  O  AHOH A 290      16.243  31.293  15.627  0.96 22.05           O  
+ANISOU 1776  O  AHOH A 290     2666   3145   2568   -361   1186    939       O  
+HETATM 1777  O  AHOH A 291      14.064  33.077  16.789  0.88 18.75           O  
+ANISOU 1777  O  AHOH A 291     2739   2106   2280   -869    197   -307       O  
+HETATM 1778  O   HOH A 292       4.313   8.978  -9.358  1.00 25.26           O  
+ANISOU 1778  O   HOH A 292     3084   3396   3117    313    291   -167       O  
+HETATM 1779  O  AHOH A 293      18.634  17.578  13.716  0.79 25.53           O  
+ANISOU 1779  O  AHOH A 293     3083   3315   3301    -46     28   -268       O  
+HETATM 1780  O   HOH A 294      -2.360  25.710  12.310  1.00 23.41           O  
+ANISOU 1780  O   HOH A 294     2784   2819   3292    310   -584    -96       O  
+HETATM 1781  O   HOH A 295       2.235   7.500  -9.249  1.00 26.71           O  
+ANISOU 1781  O   HOH A 295     3387   3220   3542   -350     99   -139       O  
+HETATM 1782  O   HOH A 296      -0.974  29.048  15.574  1.00 26.33           O  
+ANISOU 1782  O   HOH A 296     3301   3347   3357    -91    440   -304       O  
+HETATM 1783  O   HOH A 297      18.902  18.776   8.153  1.00 27.72           O  
+ANISOU 1783  O   HOH A 297     3486   3341   3704    214    209    119       O  
+HETATM 1784  O   HOH A 298       1.722  17.115  -2.833  1.00 17.99           O  
+ANISOU 1784  O   HOH A 298     2827   2135   1875    208   -685   -203       O  
+HETATM 1785  O   HOH A 299      -2.735  27.261  22.735  1.00 18.09           O  
+ANISOU 1785  O   HOH A 299     2195   2818   1861   -234    677   -263       O  
+HETATM 1786  O  AHOH A 300      16.750  30.730  12.815  0.72 18.18           O  
+ANISOU 1786  O  AHOH A 300     1863   3206   1837   -271   -212    -84       O  
+HETATM 1787  O   HOH A 301       1.133   6.594  -7.650  1.00 21.32           O  
+ANISOU 1787  O   HOH A 301     2623   2884   2592   -147   -280    175       O  
+HETATM 1788  O   HOH A 302      15.525   9.179   1.646  1.00 20.18           O  
+ANISOU 1788  O   HOH A 302     2682   3323   1663   -349    720    251       O  
+HETATM 1789  O  AHOH A 303      -3.101  18.743  12.991  0.89 23.92           O  
+ANISOU 1789  O  AHOH A 303     2856   2755   3479   -244     85   -222       O  
+HETATM 1790  O  AHOH A 304      14.926  22.916   4.590  0.66  7.78           O  
+ANISOU 1790  O  AHOH A 304     1013   1152    790    142    195    -51       O  
+HETATM 1791  O  BHOH A 304      15.973  24.086   4.831  0.34 11.48           O  
+ANISOU 1791  O  BHOH A 304     1880   1329   1154    543    545     13       O  
+HETATM 1792  O   HOH A 305       9.045  21.396  -5.139  1.00 18.90           O  
+ANISOU 1792  O   HOH A 305     2135   2995   2051   -377    569   -767       O  
+HETATM 1793  O   HOH A 306      17.821  17.558   9.492  1.00 26.99           O  
+ANISOU 1793  O   HOH A 306     3499   3101   3655    376    422    302       O  
+HETATM 1794  O   HOH A 307      16.290  13.066  10.204  1.00 22.88           O  
+ANISOU 1794  O   HOH A 307     2599   2858   3238    564     59   -268       O  
+HETATM 1795  O   HOH A 308       8.256  18.557  -4.074  1.00 21.28           O  
+ANISOU 1795  O   HOH A 308     2937   3009   2141    119    185   -103       O  
+HETATM 1796  O   HOH A 309      18.875  26.616  18.323  1.00 23.59           O  
+ANISOU 1796  O   HOH A 309     2803   3141   3020    433   -100   -126       O  
+HETATM 1797  O   HOH A 310      20.377  15.770  13.648  1.00 26.93           O  
+ANISOU 1797  O   HOH A 310     3355   3354   3522    -45    111    100       O  
+HETATM 1798  O   HOH A 311       5.688  15.324  -3.684  1.00 25.46           O  
+ANISOU 1798  O   HOH A 311     3162   3192   3318    279   -118    133       O  
+HETATM 1799  O  AHOH A 312      16.058  26.662   3.411  0.81 27.96           O  
+ANISOU 1799  O  AHOH A 312     3508   3522   3594    -34      1    -38       O  
+HETATM 1800  O  BHOH A 313      14.719  23.287   0.567  0.87 21.96           O  
+ANISOU 1800  O  BHOH A 313     2889   2723   2732     77    832   -309       O  
+HETATM 1801  O   HOH A 314      16.329  29.232  14.050  1.00 27.27           O  
+ANISOU 1801  O   HOH A 314     3445   3457   3461    -97   -138   -222       O  
+HETATM 1802  O   HOH A 315       9.814   6.566  -4.664  1.00 32.48           O  
+ANISOU 1802  O   HOH A 315     4075   4110   4154      1     65    108       O  
+HETATM 1803  O   HOH A 316      11.135   8.884  -5.095  1.00 29.46           O  
+ANISOU 1803  O   HOH A 316     3812   3660   3722     39   -122   -381       O  
+HETATM 1804  O   HOH A 317       0.464  10.254 -11.364  1.00 19.14           O  
+ANISOU 1804  O   HOH A 317     2753   2597   1924   1286   -890   -555       O  
+HETATM 1805  O   HOH A 318      18.620  13.696  -2.933  1.00 29.53           O  
+ANISOU 1805  O   HOH A 318     3753   3861   3607    -48    -60   -728       O  
+HETATM 1806  O   HOH A 319      19.683  12.668  -1.366  1.00 31.11           O  
+ANISOU 1806  O   HOH A 319     4004   3908   3908     -7    -16    -34       O  
+HETATM 1807  O   HOH A 320       4.929  14.025  -0.569  1.00 28.06           O  
+ANISOU 1807  O   HOH A 320     3626   3418   3616    454   -644    -18       O  
+HETATM 1808  O   HOH A 321       3.796  15.055  -2.644  1.00 30.32           O  
+ANISOU 1808  O   HOH A 321     4083   3735   3704    163    204   -190       O  
+HETATM 1809  O   HOH A 322      14.483  16.525  20.391  1.00 28.32           O  
+ANISOU 1809  O   HOH A 322     3818   3482   3460    417   -758    343       O  
+HETATM 1810  O   HOH A 323      16.234  14.976  17.358  1.00 28.83           O  
+ANISOU 1810  O   HOH A 323     3519   3666   3770    226   -247    399       O  
+HETATM 1811  O  AHOH A 324      16.233  16.797  15.117  0.86 28.61           O  
+ANISOU 1811  O  AHOH A 324     3476   3546   3850    231    -80   -229       O  
+HETATM 1812  O   HOH A 325       0.280  26.929   6.880  1.00 25.26           O  
+ANISOU 1812  O   HOH A 325     3250   3049   3300    -54     32   -158       O  
+HETATM 1813  O   HOH A 326      -2.216  16.014   1.731  1.00 30.05           O  
+ANISOU 1813  O   HOH A 326     3739   3845   3832   -142   -309   -348       O  
+HETATM 1814  O   HOH A 327       4.370  30.081  -1.012  1.00 28.25           O  
+ANISOU 1814  O   HOH A 327     3653   3531   3550   -432   -381     62       O  
+HETATM 1815  O  BHOH A 328      14.024  32.787   8.492  0.78 27.87           O  
+ANISOU 1815  O  BHOH A 328     3503   3596   3490   -185     97    -54       O  
+HETATM 1816  O   HOH A 329      19.998  24.298  13.125  1.00 29.79           O  
+ANISOU 1816  O   HOH A 329     3629   3876   3815    128    106    -61       O  
+HETATM 1817  O  AHOH A 330       9.235  18.371  22.798  0.88 28.23           O  
+ANISOU 1817  O  AHOH A 330     3530   3521   3675   -200   -195   -145       O  
+HETATM 1818  O  AHOH A 331      10.177  17.034  21.653  0.76 31.00           O  
+ANISOU 1818  O  AHOH A 331     3919   3976   3885   -112   -112   -175       O  
+HETATM 1819  O   HOH A 332       7.573  17.849  23.758  1.00 28.59           O  
+ANISOU 1819  O   HOH A 332     3703   3548   3613     18    152    245       O  
+HETATM 1820  O   HOH A 333      19.942  31.313  27.910  1.00 21.30           O  
+ANISOU 1820  O   HOH A 333     2866   2922   2306   -330    139   -974       O  
+HETATM 1821  O   HOH A 334      19.852  31.679  30.609  1.00 21.96           O  
+ANISOU 1821  O   HOH A 334     2966   3520   1858   -367   -634   -154       O  
+CONECT  659 1683                                                                
+CONECT  660 1683                                                                
+CONECT 1653 1682                                                                
+CONECT 1654 1682                                                                
+CONECT 1682 1653 1654 1686                                                      
+CONECT 1683  659  660 1707 1750                                                 
+CONECT 1683 1817 1819                                                           
+CONECT 1684 1685                                                                
+CONECT 1685 1684 1686                                                           
+CONECT 1686 1682 1685                                                           
+CONECT 1707 1683                                                                
+CONECT 1750 1683                                                                
+CONECT 1817 1683                                                                
+CONECT 1819 1683                                                                
+MASTER      288    0    3    3    0    0    5    6  607    1   14    5          
+END                                                                             

--- a/test/4NPD/DEE.cfg
+++ b/test/4NPD/DEE.cfg
@@ -1,0 +1,15 @@
+% Mutation Parameter File
+% pruningE  (MinDEE)
+%
+runName 4NPD
+imindee true
+ival 1000
+doMinimize true
+useEref false
+addWT false
+addWTRots false
+resAllowed0_0 Ile Ala Gly
+resAllowed0_1 Ser Ala Gly
+resAllowed0_2 Met Ser Ala Gly
+OutputGMECStruct true
+useEllipses true

--- a/test/4NPD/KStar.cfg
+++ b/test/4NPD/KStar.cfg
@@ -1,0 +1,2 @@
+DataDir dataFiles
+DoSolvationE false

--- a/test/4NPD/System.cfg
+++ b/test/4NPD/System.cfg
@@ -1,0 +1,6 @@
+pdbName test/4NPD/4NPD.pdb
+numOfStrands 1
+strand0 1 57
+strandMutNums 3
+strandMut0 1 2 3
+strandRotTrans0 false


### PR DESCRIPTION
I renamed the original ResidueTemplateLibrary since I subclassed it; the GenericResidueTemplateLibrary should handle all default rotamer libraries we supported before and any new ones that don't require new features, such as position-specific rotamers.

The Runnable class was used to turn the if tree in Main.java into a map we initialize elsewhere. I'm actually a fan of moving it entirely into another class, since most users aren't going to be debugging the command parsing code.

Other comments indicating need for other changes are included. I'm happy to discuss.