### PR TITLE
optionally suppress warnings when using non-AAs

### DIFF
--- a/src/edu/duke/cs/osprey/control/Main.java
+++ b/src/edu/duke/cs/osprey/control/Main.java
@@ -132,7 +132,7 @@ public class Main {
 		commands.put("doMultiStateKStar", new Runnable() {
 			@Override
 			public void run() {
-				MultiStateKStarDoer msksd = new MultiStateKStarDoer(args);
+				MSKStarDoer msksd = new MSKStarDoer(args);
 				msksd.calcBestSequences();
 			}
 		});

--- a/src/edu/duke/cs/osprey/energy/forcefield/BigForcefieldEnergy.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/BigForcefieldEnergy.java
@@ -28,6 +28,7 @@ public class BigForcefieldEnergy implements EnergyFunction.DecomposableByDof, En
 	public static class ParamInfo {
 		
 		// physical constants and constant params
+		public static boolean printWarnings = true;
 		private static final double coulombConstant = 332.0;
 		private static final double solvCutoff = 9.0;
 		
@@ -655,7 +656,9 @@ public class BigForcefieldEnergy implements EnergyFunction.DecomposableByDof, En
 		if (!success) {
 			
 			// if there's no params, don't crash, use defaults instead
-			System.err.println("WARNING: couldn't find solvation parameters for atom type: " + atom.forceFieldType + ", using default values");
+			if(ParamInfo.printWarnings) {
+				System.err.println("WARNING: couldn't find solvation parameters for atom type: " + atom.forceFieldType + ", using default values");
+			}
 			solvparams.dGref = 0;
 			solvparams.dGfree = 0;
 			solvparams.volume = 0;

--- a/src/edu/duke/cs/osprey/energy/forcefield/ForcefieldParams.java
+++ b/src/edu/duke/cs/osprey/energy/forcefield/ForcefieldParams.java
@@ -20,7 +20,7 @@ import java.util.StringTokenizer;
  */
 public class ForcefieldParams implements Serializable {
     
-    
+    public static boolean printWarnings = true;
     final int atomTypeX = -2; //the atom type number for the X wildcard atom type
     private final int noMatchInt = 9999;
 
@@ -840,8 +840,10 @@ public class ForcefieldParams implements Serializable {
                 }
             }
             
-            System.out.println("Warning: No equilibrium bond length listed for atom types "
+            if(printWarnings) {
+            	System.out.println("Warning: No equilibrium bond length listed for atom types "
                     +atomType1+" and "+atomType2);
+            }
             //this is used to get an estimated bond distance matrix, in which case
             //we can estimate using other atom types for the same elements
             

--- a/src/edu/duke/cs/osprey/multistatekstar/InputValidation.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/InputValidation.java
@@ -23,7 +23,7 @@ public class InputValidation {
 		this.mutable2StateResNums = mutable2StateResNums;
 	}
 	
-	public void handleAATypeOptions(int state, int subState, MultiStateConfigFileParser stateCfp) {
+	public void handleAATypeOptions(int state, int subState, MSConfigFileParser stateCfp) {
 		//Given the config file parser for a state, make sure AATypeOptions
 		//matches the allowed AA types for this state
 

--- a/src/edu/duke/cs/osprey/multistatekstar/KStarSettings.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/KStarSettings.java
@@ -17,15 +17,15 @@ public class KStarSettings {
 	public double targetEpsilon;
 	public int state;
 	public int numTopConfsToSave;
-	public MultiStateConfigFileParser cfp;
-	public MultiStateSearchProblem[] search;
+	public MSConfigFileParser cfp;
+	public MSSearchProblem[] search;
 	public LMV[] constraints;
 	public ConfEnergyCalculator.Async[] ecalcs;
 
 	public KStarSettings() {}
 
 	public static ConfEnergyCalculator.Async makeEnergyCalculator(
-			MultiStateConfigFileParser cfp,
+			MSConfigFileParser cfp,
 			SearchProblem multiSeqSearch
 			) {
 		// make the conf energy calculator
@@ -39,8 +39,8 @@ public class KStarSettings {
 	}
 
 	public static ConfSearchFactory makeConfSearchFactory(
-			MultiStateSearchProblem singleSeqSearch, 
-			MultiStateConfigFileParser cfp
+			MSSearchProblem singleSeqSearch, 
+			MSConfigFileParser cfp
 			) {
 		ConfSearchFactory confSearchFactory = ConfSearchFactory.Tools.makeFromConfig(singleSeqSearch, cfp);
 		return confSearchFactory;

--- a/src/edu/duke/cs/osprey/multistatekstar/MSConfigFileParser.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/MSConfigFileParser.java
@@ -16,17 +16,17 @@ import edu.duke.cs.osprey.tools.ObjectIO;
 import edu.duke.cs.osprey.tools.StringParsing;
 import edu.duke.cs.osprey.tupexp.LUTESettings;
 
-public class MultiStateConfigFileParser extends ConfigFileParser {
+public class MSConfigFileParser extends ConfigFileParser {
 
-	public MultiStateConfigFileParser(String[] args, boolean isVerbose) {
+	public MSConfigFileParser(String[] args, boolean isVerbose) {
 		super(args, isVerbose);
 	}
 
-	public MultiStateConfigFileParser(String[] args) {
+	public MSConfigFileParser(String[] args) {
 		super(args);
 	}
 
-	public MultiStateConfigFileParser() {
+	public MSConfigFileParser() {
 		super();
 	}
 

--- a/src/edu/duke/cs/osprey/multistatekstar/MSKStarTree.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/MSKStarTree.java
@@ -12,15 +12,16 @@ import edu.duke.cs.osprey.confspace.SearchProblem;
  * @author Adegoke Ojewole (ao68@duke.edu)
  *
  */
-public class MultiStateKStarTree extends AStarTree<FullAStarNode> {
+public class MSKStarTree extends AStarTree<FullAStarNode> {
 
-	int numTreeLevels;//number of residues with sequence changes
+	int numTreeLevels;//number of residues with sequence changes+1
+	//level if we are doing continuous minimization
 
-	LMV objFcn;//we are minimizing objFcn...
+	LMV objFcn;//we are minimizing objFcn
 	LMV[] kssConstraints;
 	LMV[][] pfConstraints;
 
-	ArrayList<ArrayList<String>> AATypeOptions;
+	ArrayList<ArrayList<ArrayList<ArrayList<String>>>> AATypeOptions;
 	// MultiStateKStarTreeNode.assignments Assigns each level an index in 
 	// AATypeOptions.get(level), and thus an AA type
 	//If -1, then no assignment yet
@@ -31,10 +32,10 @@ public class MultiStateKStarTree extends AStarTree<FullAStarNode> {
 	//information on states
 
 	int numStates;//how many states there are
-	//states have the same mutable residues & AA options,
-	//though the residues involved may be otherwise different
+	//states have the same mutable residues & options for AA residues,
+	//but not necessarily for non AA residues
 
-	SearchProblem stateSP[][];//SearchProblems describing them
+	SearchProblem search[][];//SearchProblems describing them
 	//each state has >= 3 SearchProblems
 
 	ArrayList<ArrayList<Integer>> mutable2StatePosNums;
@@ -51,7 +52,7 @@ public class MultiStateKStarTree extends AStarTree<FullAStarNode> {
 
 	private static final long serialVersionUID = 1L;
 
-	public MultiStateKStarTree(
+	public MSKStarTree(
 			int numTreeLevels, 
 			LMV objFcn, 
 			LMV[] constraints,

--- a/src/edu/duke/cs/osprey/multistatekstar/MSSearchProblem.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/MSSearchProblem.java
@@ -5,11 +5,11 @@ import edu.duke.cs.osprey.confspace.SearchProblem;
 import edu.duke.cs.osprey.pruning.Pruner;
 
 @SuppressWarnings("serial")
-public class MultiStateSearchProblem extends SearchProblem {
+public class MSSearchProblem extends SearchProblem {
 
 	SearchSettings settings;
 
-	public MultiStateSearchProblem(SearchProblem other, 
+	public MSSearchProblem(SearchProblem other, 
 			SearchSettings settings) {
 		super(other);
 		if(settings==null) throw new RuntimeException("ERROR: search settings cannot be null");
@@ -32,7 +32,7 @@ public class MultiStateSearchProblem extends SearchProblem {
 
 		BigInteger numDesiredConfs = BigInteger.valueOf(65536);
 		
-		// single sequence type dependent pruning for better efficiency
+		//single sequence type dependent pruning for better efficiency
 		//now do any consequent singles & pairs pruning
 		int numUpdates = ((QPruningMatrix)pruneMat).countUpdates();
 		int oldNumUpdates;
@@ -40,14 +40,21 @@ public class MultiStateSearchProblem extends SearchProblem {
 		Pruner dee = new Pruner(search, pruneMat, true, stericThresh, pruningWindow, 
 				search.useEPIC, search.useTupExpForSearch);
 		dee.setVerbose(false);
+		
+		//limit amount of time (in minutes) spent pruning
+		double start = System.currentTimeMillis(), duration, timeout = 60;
 
 		do {//repeat as long as we're pruning things
 			oldNumUpdates = numUpdates;
 			dee.prune("GOLDSTEIN");
 			dee.prune("GOLDSTEIN PAIRS FULL");
 			numUpdates = ((QPruningMatrix)pruneMat).countUpdates();
+			
+			duration = (System.currentTimeMillis()-start)/(60*1000.0);
+			
 		} while (numUpdates > oldNumUpdates && 
-				((QPruningMatrix)pruneMat).getNumReducedUnprunedConfs().compareTo(numDesiredConfs) > 0);
+				((QPruningMatrix)pruneMat).getNumReducedUnprunedConfs().compareTo(numDesiredConfs) > 0 &&
+				duration < timeout);
 		
 	}
 }

--- a/src/edu/duke/cs/osprey/multistatekstar/ParallelPartitionFunction.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/ParallelPartitionFunction.java
@@ -264,7 +264,7 @@ public class ParallelPartitionFunction extends ParallelConfPartitionFunction {
 					// report progress if needed
 					if (isReportingProgress) {
 						MemoryUsage heapMem = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage();
-						System.out.println(String.format("conf: %4d, energy: %.6f, q*: %12e, q': %12e, p*-p1*: %12e, epsilon: %.6f, time: %10s, heapMem: %.0f%%",
+						System.out.println(String.format("conf: %4d, energy: %.6f, q*: %12e, q': %12e, score diff: %12e, epsilon: %.6f, time: %10s, heapMem: %.0f%%",
 								numConfsEvaluated, econf.getEnergy(), values.qstar, values.qprime, pdiff, values.getEffectiveEpsilon(),
 								stopwatch.getTime(2),
 								100f*heapMem.getUsed()/heapMem.getMax()

--- a/src/edu/duke/cs/osprey/multistatekstar/ParallelPartitionFunction.java
+++ b/src/edu/duke/cs/osprey/multistatekstar/ParallelPartitionFunction.java
@@ -33,7 +33,7 @@ public class ParallelPartitionFunction extends ParallelConfPartitionFunction {
 		econfs = null;
 	}
 
-	protected void writeTopConfs(int state, MultiStateSearchProblem search) {
+	protected void writeTopConfs(int state, MSSearchProblem search) {
 		if(econfs==null || econfs.size()==0) return;
 		String seq = search.settings.getFormattedSequence();
 		if(isReportingProgress) {


### PR DESCRIPTION
also, limit the amount of time spent pruning for K*.